### PR TITLE
Scraper: extract PDF URL per record, limit to first page (closes #8)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,13 +125,13 @@ logs-api:
 	sam logs -n ApiFunction --stack-name $(STACK_NAME) --tail
 
 get-api-key:
-	@KEY_ID=$$(aws apigateway get-api-keys \
-		--name-query "probate-leads-api" \
-		--include-values \
-		--query 'items[0].id' \
+	@KEY_ID=$$(aws cloudformation describe-stack-resources \
+		--stack-name $(STACK_NAME) \
+		--region $(REGION) \
+		--query 'StackResources[?ResourceType==`AWS::ApiGateway::ApiKey`].PhysicalResourceId | [0]' \
 		--output text); \
 	aws apigateway get-api-key --api-key $$KEY_ID --include-value \
-		--query 'value' --output text
+		--query 'value' --output text --region $(REGION)
 
 invoke-trigger:
 	sam local invoke TriggerFunction \

--- a/src/scraper/scraper.py
+++ b/src/scraper/scraper.py
@@ -3,9 +3,10 @@ Collin County probate records scraper.
 Ported from probate-scraper.ipynb — functions kept at same names for traceability.
 Key changes from notebook:
   - initialize_driver() uses CHROMEDRIVER_PATH env var (not webdriver-manager)
-  - scrape_all() replaces scrape_collin_county_records(): no max_pages cap,
-    writes to DynamoDB after each page (resilient to crashes),
-    accepts location_code so records are tagged with their source location.
+  - scrape_all() scrapes only the first page (most-recent records, sorted desc).
+  - extract_page_data() adds pdf_url to every record:
+      first checks for an inline document link in the row;
+      if absent, clicks the row to open the detail panel and extracts it there.
 """
 
 import os
@@ -16,6 +17,7 @@ from datetime import datetime
 
 from selenium import webdriver
 from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.chrome.options import Options
@@ -49,7 +51,34 @@ SEARCH_PARAMS = {
 }
 
 PAGE_LOAD_WAIT = 10   # seconds to sleep after driver.get()
-DELAY_BETWEEN_PAGES = int(os.environ.get("DELAY_BETWEEN_PAGES", "3"))
+DETAIL_WAIT    = 3    # seconds to wait for the detail panel to open
+
+# CSS selectors tried in order when looking for a document link directly in the row
+ROW_PDF_SELECTORS = [
+    'a[href*="/doc/"]',
+    'a[href*=".pdf"]',
+    'a[href*="/document/"]',
+    'a[href*="/images/"]',
+]
+
+# CSS selectors tried in order to locate the detail panel after clicking a row
+DETAIL_PANEL_SELECTORS = [
+    ".document-detail",
+    ".record-detail",
+    ".doc-viewer",
+    ".document-viewer",
+    '[class*="document-detail"]',
+    '[class*="record-detail"]',
+]
+
+# CSS selectors tried in order to find the document link inside the detail panel
+PANEL_PDF_SELECTORS = [
+    'a[href*="/doc/"]',
+    'a[href*=".pdf"]',
+    'a[href*="/document/"]',
+    'a[href*="/images/"]',
+    ".document-pdf-link",
+]
 
 
 # ---------------------------------------------------------------------------
@@ -113,50 +142,7 @@ def load_page(driver, url, wait_time=PAGE_LOAD_WAIT):
 
 
 # ---------------------------------------------------------------------------
-# Cell 5: Pagination sentinel
-# ---------------------------------------------------------------------------
-
-def has_more_pages(driver, current_offset, limit=50):
-    """
-    Return True if there are more pages beyond current_offset.
-    Primary: count records on the current page; if < limit, we're at the end.
-    Secondary: look for explicit 'no results' DOM indicators.
-    """
-    record_selectors = [
-        ".record", ".result-item", ".search-result",
-        "tr.record-row", ".data-row", "[data-record]", ".result",
-    ]
-    actual_count = 0
-    for sel in record_selectors:
-        try:
-            elems = driver.find_elements(By.CSS_SELECTOR, sel)
-            if elems:
-                actual_count = len(elems)
-                break
-        except Exception:
-            continue
-
-    if actual_count < limit:
-        log.info("Found %d records (< limit %d) — end of results", actual_count, limit)
-        return False
-
-    no_results_selectors = [
-        ".no-results", ".no-more-results", ".end-of-results", "[data-no-results]",
-    ]
-    for sel in no_results_selectors:
-        try:
-            elem = driver.find_element(By.CSS_SELECTOR, sel)
-            if elem.is_displayed():
-                log.info("'No more results' indicator found")
-                return False
-        except Exception:
-            continue
-
-    return True
-
-
-# ---------------------------------------------------------------------------
-# Cell 6: Data extraction
+# Cell 5: Data extraction helpers
 # ---------------------------------------------------------------------------
 
 def get_total_results(driver):
@@ -191,10 +177,90 @@ def get_total_results(driver):
         return None
 
 
+def get_pdf_url_from_row(row) -> str | None:
+    """
+    Return the document URL if a link is directly present in the row, else None.
+    Tries ROW_PDF_SELECTORS in order.
+    """
+    for sel in ROW_PDF_SELECTORS:
+        try:
+            link = row.find_element(By.CSS_SELECTOR, sel)
+            href = link.get_attribute("href")
+            if href:
+                log.debug("Inline PDF link found (%s): %s", sel, href)
+                return href
+        except Exception:
+            continue
+    return None
+
+
+def get_pdf_url_by_clicking(driver, row) -> str | None:
+    """
+    Click the row to open its detail panel, extract the document URL,
+    then dismiss the panel with Escape. Returns the URL or None on failure.
+    """
+    try:
+        row.click()
+        time.sleep(DETAIL_WAIT)
+
+        # Find the detail panel
+        panel = None
+        for sel in DETAIL_PANEL_SELECTORS:
+            try:
+                panel = WebDriverWait(driver, 5).until(
+                    EC.visibility_of_element_located((By.CSS_SELECTOR, sel))
+                )
+                log.debug("Detail panel found (%s)", sel)
+                break
+            except Exception:
+                continue
+
+        if panel is None:
+            log.warning("No detail panel found after clicking row")
+            return None
+
+        # Find the document link inside the panel
+        for sel in PANEL_PDF_SELECTORS:
+            try:
+                link = panel.find_element(By.CSS_SELECTOR, sel)
+                href = link.get_attribute("href")
+                if href:
+                    log.debug("PDF link found in panel (%s): %s", sel, href)
+                    # Dismiss the panel
+                    try:
+                        driver.find_element(By.TAG_NAME, "body").send_keys(Keys.ESCAPE)
+                        time.sleep(0.5)
+                    except Exception:
+                        pass
+                    return href
+            except Exception:
+                continue
+
+        log.warning("No document link found in detail panel")
+        return None
+
+    except Exception as exc:
+        log.warning("get_pdf_url_by_clicking error: %s", exc)
+        return None
+
+
+def get_pdf_url(driver, row) -> str | None:
+    """
+    Get the PDF/document URL for a result row.
+    First checks for an inline link in the row; falls back to clicking the row
+    to open the detail panel.
+    """
+    url = get_pdf_url_from_row(row)
+    if url:
+        return url
+    log.debug("No inline PDF link — clicking row to open detail panel")
+    return get_pdf_url_by_clicking(driver, row)
+
+
 def extract_page_data(driver):
     """
     Extract all record rows from the current page.
-    Returns a list of dicts with 9 fields (grantor … legal_description + metadata).
+    Returns a list of dicts with fields including pdf_url.
     Skips the first two table rows (header + empty spacer).
     Continues past individual row errors rather than aborting the whole page.
     """
@@ -224,6 +290,7 @@ def extract_page_data(driver):
                     "doc_number":        _text('td.col-7[column="[object Object]"] span'),
                     "book_volume_page":  _text('td.col-8[column="[object Object]"] span'),
                     "legal_description": _text("td.col-9"),
+                    "pdf_url":           get_pdf_url(driver, row),
                     "record_number":     i,
                     "extracted_at":      datetime.utcnow().isoformat(),
                 }
@@ -240,64 +307,50 @@ def extract_page_data(driver):
 
 
 # ---------------------------------------------------------------------------
-# Main scrape loop (replaces scrape_collin_county_records)
+# Main scrape entry point
 # ---------------------------------------------------------------------------
 
 def scrape_all(scrape_run_id: str, location_code: str):
     """
-    Scrape every page of results, writing to DynamoDB after each page.
-    No max_pages cap — runs until has_more_pages() returns False.
+    Scrape the first page of results (most recent, sorted descending) and
+    write records to DynamoDB.  Each record includes a pdf_url field — sourced
+    directly from the row link if present, otherwise by clicking the row to
+    open the detail panel.
 
     Args:
         scrape_run_id:  Unique identifier for this run (injected by ECS or caller).
         location_code:  FK into the locations table (e.g. "CollinTx").
     """
     table_name = os.environ["DYNAMO_TABLE_NAME"]
-    limit = int(SEARCH_PARAMS["limit"])
-    current_offset = 0
-    page_num = 1
-    total_written = 0
 
     driver = initialize_driver()
     try:
-        while True:
-            log.info("=== Page %d (offset %d) ===", page_num, current_offset)
-            url = build_search_url(SEARCH_PARAMS, offset=current_offset)
+        url = build_search_url(SEARCH_PARAMS, offset=0)
+        log.info("=== Scraping first page ===")
 
-            if not load_page(driver, url):
-                log.error("Failed to load page %d — stopping", page_num)
-                break
+        if not load_page(driver, url):
+            log.error("Failed to load first page — aborting")
+            return 0
 
-            page_records = extract_page_data(driver)
+        page_records = extract_page_data(driver)
 
-            if page_records:
-                for rec in page_records:
-                    rec["page_number"] = page_num
-                    rec["offset"] = current_offset
+        if not page_records:
+            log.warning("No records found on first page")
+            return 0
 
-                written = dynamo.write_records(
-                    page_records, table_name, scrape_run_id, location_code
-                )
-                total_written += written
-                log.info("Wrote %d records (total so far: %d)", written, total_written)
-            else:
-                log.warning("No records on page %d — stopping", page_num)
-                break
+        for rec in page_records:
+            rec["page_number"] = 1
+            rec["offset"] = 0
 
-            if not has_more_pages(driver, current_offset, limit):
-                log.info("No more pages — scrape complete")
-                break
-
-            current_offset += limit
-            page_num += 1
-            time.sleep(DELAY_BETWEEN_PAGES)
+        written = dynamo.write_records(
+            page_records, table_name, scrape_run_id, location_code
+        )
+        log.info(
+            "Scrape finished: %d records written (location=%s)",
+            written, location_code,
+        )
+        return written
 
     finally:
         driver.quit()
         log.info("WebDriver closed")
-
-    log.info(
-        "Scrape finished: %d total records written across %d pages (location=%s)",
-        total_written, page_num, location_code,
-    )
-    return total_written

--- a/tests/fixtures/scraper_html.py
+++ b/tests/fixtures/scraper_html.py
@@ -1,0 +1,102 @@
+"""
+Mock HTML for Collin County probate search results
+(https://collin.tx.publicsearch.us/results).
+
+Used as the reference source for mock Selenium elements in scraper tests.
+The structure mirrors the live page's table layout and CSS selectors used
+in extract_page_data():
+  td.col-3  — grantor
+  td.col-4  — grantee
+  td.col-5  — doc_type   (inside <em>)
+  td.col-6  — recorded_date
+  td.col-7  — doc_number  (+ optional <a> document link)
+  td.col-8  — book_volume_page
+  td.col-9  — legal_description
+"""
+
+MOCK_PAGE_HTML = """\
+<!DOCTYPE html>
+<html>
+<head><title>Search Results — Collin County Clerk</title></head>
+<body>
+  <div class="results-header">
+    <span aria-label="Search Result Totals">1-50 of 6,720 results</span>
+  </div>
+
+  <table>
+    <!-- Row 0: header (skipped by extract_page_data) -->
+    <tr>
+      <th></th><th></th>
+      <th>Grantor</th><th>Grantee</th><th>Doc Type</th>
+      <th>Recorded Date</th><th>Doc Number</th><th>Book/Vol Page</th>
+      <th>Legal Description</th>
+    </tr>
+    <!-- Row 1: spacer (skipped by extract_page_data) -->
+    <tr class="spacer-row"><td colspan="9">&nbsp;</td></tr>
+
+    <!-- Row 2: data row WITH an inline document link -->
+    <tr class="data-row">
+      <td class="col-1"></td>
+      <td class="col-2"></td>
+      <td class="col-3" column="[object Object]"><span>SMITH JOHN A</span></td>
+      <td class="col-4" column="[object Object]"><span>JONES MARY B</span></td>
+      <td class="col-5" column="[object Object]"><span><em>PROBATE</em></span></td>
+      <td class="col-6" column="[object Object]"><span>01/15/2024</span></td>
+      <td class="col-7" column="[object Object]">
+        <span>20240001234</span>
+        <a href="https://collin.tx.publicsearch.us/doc/20240001234">
+          <img src="/icons/pdf.svg" alt="View document" />
+        </a>
+      </td>
+      <td class="col-8" column="[object Object]"><span></span></td>
+      <td class="col-9">LOT 5 BLK 3 SUNNY ACRES PH 1</td>
+    </tr>
+
+    <!-- Row 3: data row WITHOUT an inline link (requires clicking) -->
+    <tr class="data-row">
+      <td class="col-1"></td>
+      <td class="col-2"></td>
+      <td class="col-3" column="[object Object]"><span>DOE JANE E</span></td>
+      <td class="col-4" column="[object Object]"><span>DOE JOHN E</span></td>
+      <td class="col-5" column="[object Object]"><span><em>PROBATE</em></span></td>
+      <td class="col-6" column="[object Object]"><span>02/20/2024</span></td>
+      <td class="col-7" column="[object Object]"><span>20240005678</span></td>
+      <td class="col-8" column="[object Object]"><span></span></td>
+      <td class="col-9">LOT 12 BLK 7 HERITAGE PARK</td>
+    </tr>
+  </table>
+
+  <!-- Detail panel — hidden until a row is clicked -->
+  <div class="document-detail" style="display:none">
+    <h2>Document Detail</h2>
+    <a href="https://collin.tx.publicsearch.us/doc/20240005678">
+      View Document
+    </a>
+    <button class="close-panel">Close</button>
+  </div>
+</body>
+</html>
+"""
+
+# Expected parsed values matching the HTML above
+ROW_WITH_PDF = {
+    "grantor":           "SMITH JOHN A",
+    "grantee":           "JONES MARY B",
+    "doc_type":          "PROBATE",
+    "recorded_date":     "01/15/2024",
+    "doc_number":        "20240001234",
+    "book_volume_page":  "",
+    "legal_description": "LOT 5 BLK 3 SUNNY ACRES PH 1",
+    "pdf_url":           "https://collin.tx.publicsearch.us/doc/20240001234",
+}
+
+ROW_WITHOUT_PDF_INLINE = {
+    "grantor":           "DOE JANE E",
+    "grantee":           "DOE JOHN E",
+    "doc_type":          "PROBATE",
+    "recorded_date":     "02/20/2024",
+    "doc_number":        "20240005678",
+    "book_volume_page":  "",
+    "legal_description": "LOT 12 BLK 7 HERITAGE PARK",
+    "pdf_url":           "https://collin.tx.publicsearch.us/doc/20240005678",  # found via click
+}

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -1,0 +1,470 @@
+"""
+Unit tests for src/scraper/scraper.py
+
+All tests use mock Selenium elements — no browser or network required.
+The mock structure mirrors the CSS selectors used in the live scraper.
+"""
+
+import sys
+import os
+import unittest
+from unittest.mock import MagicMock, patch, call
+
+# ---------------------------------------------------------------------------
+# Ensure the scraper package is importable and dynamo is mocked out
+# ---------------------------------------------------------------------------
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src", "scraper"))
+
+# dynamo is only needed for scrape_all(); mock it before the module loads
+dynamo_mock = MagicMock()
+sys.modules["dynamo"] = dynamo_mock
+
+from selenium.webdriver.common.by import By                     # noqa: E402
+from selenium.common.exceptions import NoSuchElementException   # noqa: E402
+
+import scraper  # noqa: E402  (imported after sys.modules patch)
+from scraper import (
+    build_search_url,
+    get_pdf_url_from_row,
+    get_pdf_url_by_clicking,
+    get_pdf_url,
+    extract_page_data,
+    get_total_results,
+    scrape_all,
+    SEARCH_PARAMS,
+)
+
+from tests.fixtures.scraper_html import ROW_WITH_PDF, ROW_WITHOUT_PDF_INLINE  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _elem(text: str) -> MagicMock:
+    """Return a mock Selenium element whose .text equals *text*."""
+    e = MagicMock()
+    e.text = text
+    return e
+
+
+def _link(href: str) -> MagicMock:
+    """Return a mock <a> element whose href attribute equals *href*."""
+    e = MagicMock()
+    e.get_attribute.return_value = href
+    return e
+
+
+# CSS selector → text value for a standard data row
+_TEXT_MAP = {
+    'td.col-3[column="[object Object]"] span': "SMITH JOHN A",
+    'td.col-4[column="[object Object]"] span': "JONES MARY B",
+    'td.col-5[column="[object Object]"] span em': "PROBATE",
+    'td.col-6[column="[object Object]"] span': "01/15/2024",
+    'td.col-7[column="[object Object]"] span': "20240001234",
+    'td.col-8[column="[object Object]"] span': "",
+    'td.col-9': "LOT 5 BLK 3 SUNNY ACRES PH 1",
+}
+
+
+def _make_row(pdf_href: str | None = None) -> MagicMock:
+    """
+    Build a mock TR element.
+
+    If *pdf_href* is given the row contains an inline document link;
+    otherwise find_element raises NoSuchElementException for link selectors.
+    """
+    row = MagicMock()
+    pdf_selectors = scraper.ROW_PDF_SELECTORS
+
+    def find_element(by, sel):
+        if sel in _TEXT_MAP:
+            return _elem(_TEXT_MAP[sel])
+        if pdf_href and sel in pdf_selectors:
+            return _link(pdf_href)
+        raise NoSuchElementException(f"No element: {sel}")
+
+    row.find_element.side_effect = find_element
+    return row
+
+
+def _make_driver_with_rows(*rows: MagicMock, total_text: str = "1-50 of 6,720 results"):
+    """
+    Build a mock WebDriver containing a single table whose rows are:
+      [header_row, spacer_row, *rows]
+    """
+    driver = MagicMock()
+
+    # Search Result Totals span
+    totals_span = _elem(total_text)
+    driver.find_element.return_value = totals_span
+
+    # Table structure
+    header = MagicMock()
+    spacer = MagicMock()
+    table = MagicMock()
+    table.find_elements.return_value = [header, spacer, *rows]
+    driver.find_elements.return_value = [table]
+
+    return driver
+
+
+# ---------------------------------------------------------------------------
+# build_search_url
+# ---------------------------------------------------------------------------
+
+class TestBuildSearchUrl(unittest.TestCase):
+
+    def test_default_offset(self):
+        url = build_search_url(SEARCH_PARAMS)
+        self.assertIn("offset=0", url)
+        self.assertIn("searchValue=probate", url)
+        self.assertIn("collin.tx.publicsearch.us/results", url)
+
+    def test_custom_offset(self):
+        url = build_search_url(SEARCH_PARAMS, offset=50)
+        self.assertIn("offset=50", url)
+
+    def test_does_not_mutate_params(self):
+        original = SEARCH_PARAMS.copy()
+        build_search_url(SEARCH_PARAMS, offset=99)
+        self.assertEqual(SEARCH_PARAMS, original)
+
+
+# ---------------------------------------------------------------------------
+# get_total_results
+# ---------------------------------------------------------------------------
+
+class TestGetTotalResults(unittest.TestCase):
+
+    def test_parses_standard_format(self):
+        driver = MagicMock()
+        driver.find_element.return_value = _elem("1-50 of 6,720 results")
+        self.assertEqual(get_total_results(driver), 6720)
+
+    def test_parses_small_count(self):
+        driver = MagicMock()
+        driver.find_element.return_value = _elem("1-3 of 3 results")
+        self.assertEqual(get_total_results(driver), 3)
+
+    def test_returns_none_on_missing_element(self):
+        driver = MagicMock()
+        driver.find_element.side_effect = NoSuchElementException("not found")
+        self.assertIsNone(get_total_results(driver))
+
+    def test_returns_none_on_unparseable_text(self):
+        driver = MagicMock()
+        driver.find_element.return_value = _elem("No results found")
+        self.assertIsNone(get_total_results(driver))
+
+
+# ---------------------------------------------------------------------------
+# get_pdf_url_from_row
+# ---------------------------------------------------------------------------
+
+class TestGetPdfUrlFromRow(unittest.TestCase):
+
+    def test_returns_href_when_link_present(self):
+        row = _make_row(pdf_href="https://collin.tx.publicsearch.us/doc/20240001234")
+        result = get_pdf_url_from_row(row)
+        self.assertEqual(result, "https://collin.tx.publicsearch.us/doc/20240001234")
+
+    def test_returns_none_when_no_link(self):
+        row = _make_row(pdf_href=None)
+        result = get_pdf_url_from_row(row)
+        self.assertIsNone(result)
+
+    def test_returns_none_when_link_has_empty_href(self):
+        row = MagicMock()
+        link = MagicMock()
+        link.get_attribute.return_value = ""
+        row.find_element.return_value = link
+        result = get_pdf_url_from_row(row)
+        self.assertIsNone(result)
+
+
+# ---------------------------------------------------------------------------
+# get_pdf_url_by_clicking
+# ---------------------------------------------------------------------------
+
+class TestGetPdfUrlByClicking(unittest.TestCase):
+
+    def _make_panel(self, pdf_href: str) -> MagicMock:
+        panel = MagicMock()
+        link = _link(pdf_href)
+        panel.find_element.return_value = link
+        return panel
+
+    @patch("scraper.WebDriverWait")
+    @patch("scraper.time.sleep")
+    def test_returns_href_from_panel(self, mock_sleep, mock_wait):
+        driver = MagicMock()
+        row = MagicMock()
+        panel = self._make_panel("https://collin.tx.publicsearch.us/doc/99999")
+
+        mock_wait.return_value.until.return_value = panel
+
+        result = get_pdf_url_by_clicking(driver, row)
+        self.assertEqual(result, "https://collin.tx.publicsearch.us/doc/99999")
+        row.click.assert_called_once()
+
+    @patch("scraper.WebDriverWait")
+    @patch("scraper.time.sleep")
+    def test_returns_none_when_panel_not_found(self, mock_sleep, mock_wait):
+        driver = MagicMock()
+        row = MagicMock()
+        mock_wait.return_value.until.side_effect = Exception("timeout")
+
+        result = get_pdf_url_by_clicking(driver, row)
+        self.assertIsNone(result)
+
+    @patch("scraper.WebDriverWait")
+    @patch("scraper.time.sleep")
+    def test_returns_none_when_link_not_in_panel(self, mock_sleep, mock_wait):
+        driver = MagicMock()
+        row = MagicMock()
+        panel = MagicMock()
+        panel.find_element.side_effect = NoSuchElementException("not found")
+        mock_wait.return_value.until.return_value = panel
+
+        result = get_pdf_url_by_clicking(driver, row)
+        self.assertIsNone(result)
+
+    @patch("scraper.WebDriverWait")
+    @patch("scraper.time.sleep")
+    def test_dismisses_panel_with_escape(self, mock_sleep, mock_wait):
+        driver = MagicMock()
+        body = MagicMock()
+        driver.find_element.return_value = body
+        row = MagicMock()
+        panel = self._make_panel("https://collin.tx.publicsearch.us/doc/11111")
+        mock_wait.return_value.until.return_value = panel
+
+        get_pdf_url_by_clicking(driver, row)
+        body.send_keys.assert_called_once()  # Escape key sent
+
+
+# ---------------------------------------------------------------------------
+# get_pdf_url  (orchestrator)
+# ---------------------------------------------------------------------------
+
+class TestGetPdfUrl(unittest.TestCase):
+
+    def test_uses_inline_link_when_available(self):
+        driver = MagicMock()
+        row = _make_row(pdf_href="https://collin.tx.publicsearch.us/doc/INLINE")
+        result = get_pdf_url(driver, row)
+        self.assertEqual(result, "https://collin.tx.publicsearch.us/doc/INLINE")
+
+    @patch("scraper.get_pdf_url_by_clicking", return_value="https://collin.tx.publicsearch.us/doc/CLICKED")
+    def test_falls_back_to_clicking_when_no_inline_link(self, mock_click):
+        driver = MagicMock()
+        row = _make_row(pdf_href=None)
+        result = get_pdf_url(driver, row)
+        self.assertEqual(result, "https://collin.tx.publicsearch.us/doc/CLICKED")
+        mock_click.assert_called_once_with(driver, row)
+
+    @patch("scraper.get_pdf_url_by_clicking", return_value=None)
+    def test_returns_none_when_both_strategies_fail(self, mock_click):
+        driver = MagicMock()
+        row = _make_row(pdf_href=None)
+        result = get_pdf_url(driver, row)
+        self.assertIsNone(result)
+
+
+# ---------------------------------------------------------------------------
+# extract_page_data
+# ---------------------------------------------------------------------------
+
+class TestExtractPageData(unittest.TestCase):
+
+    def test_extracts_record_with_inline_pdf(self):
+        row = _make_row(pdf_href="https://collin.tx.publicsearch.us/doc/20240001234")
+        driver = _make_driver_with_rows(row)
+
+        records = extract_page_data(driver)
+
+        self.assertEqual(len(records), 1)
+        r = records[0]
+        self.assertEqual(r["grantor"],           ROW_WITH_PDF["grantor"])
+        self.assertEqual(r["grantee"],           ROW_WITH_PDF["grantee"])
+        self.assertEqual(r["doc_type"],          ROW_WITH_PDF["doc_type"])
+        self.assertEqual(r["recorded_date"],     ROW_WITH_PDF["recorded_date"])
+        self.assertEqual(r["doc_number"],        ROW_WITH_PDF["doc_number"])
+        self.assertEqual(r["legal_description"], ROW_WITH_PDF["legal_description"])
+        self.assertEqual(r["pdf_url"],           ROW_WITH_PDF["pdf_url"])
+
+    @patch("scraper.get_pdf_url_by_clicking",
+           return_value="https://collin.tx.publicsearch.us/doc/20240005678")
+    def test_extracts_pdf_via_click_when_not_inline(self, mock_click):
+        row = _make_row(pdf_href=None)
+        driver = _make_driver_with_rows(row)
+
+        records = extract_page_data(driver)
+
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]["pdf_url"],
+                         "https://collin.tx.publicsearch.us/doc/20240005678")
+        mock_click.assert_called_once()
+
+    def test_includes_record_number_and_extracted_at(self):
+        row = _make_row(pdf_href="https://collin.tx.publicsearch.us/doc/X")
+        driver = _make_driver_with_rows(row)
+
+        records = extract_page_data(driver)
+
+        self.assertEqual(records[0]["record_number"], 1)
+        self.assertIn("extracted_at", records[0])
+        self.assertIsNotNone(records[0]["extracted_at"])
+
+    def test_returns_empty_list_for_empty_table(self):
+        driver = MagicMock()
+        driver.find_element.return_value = _elem("0 results")
+        table = MagicMock()
+        table.find_elements.return_value = []   # no rows
+        driver.find_elements.return_value = [table]
+
+        records = extract_page_data(driver)
+        self.assertEqual(records, [])
+
+    def test_skips_header_and_spacer_rows(self):
+        """Only rows[2:] should be processed."""
+        data_row = _make_row(pdf_href="https://collin.tx.publicsearch.us/doc/1")
+        driver = _make_driver_with_rows(data_row)
+
+        records = extract_page_data(driver)
+        # The two injected header/spacer rows must not appear as records
+        self.assertEqual(len(records), 1)
+
+    def test_multiple_rows_extracted(self):
+        row1 = _make_row(pdf_href="https://collin.tx.publicsearch.us/doc/1")
+        row2 = _make_row(pdf_href="https://collin.tx.publicsearch.us/doc/2")
+        driver = _make_driver_with_rows(row1, row2)
+
+        records = extract_page_data(driver)
+        self.assertEqual(len(records), 2)
+        self.assertEqual(records[0]["record_number"], 1)
+        self.assertEqual(records[1]["record_number"], 2)
+
+    @patch("scraper.get_pdf_url")
+    def test_row_error_does_not_abort_page(self, mock_get_pdf):
+        """An unexpected error in one row should be skipped; the next row is still processed."""
+        # First call raises (simulates an unexpected error escaping all inner try/excepts)
+        # Second call returns a valid URL
+        mock_get_pdf.side_effect = [
+            Exception("unexpected DOM explosion"),
+            "https://collin.tx.publicsearch.us/doc/OK",
+        ]
+        row1 = _make_row()
+        row2 = _make_row()
+        driver = _make_driver_with_rows(row1, row2)
+
+        records = extract_page_data(driver)
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]["pdf_url"], "https://collin.tx.publicsearch.us/doc/OK")
+
+    def test_stops_at_first_table_with_data(self):
+        """extract_page_data() should not process a second table once the first yields rows."""
+        row = _make_row(pdf_href="https://collin.tx.publicsearch.us/doc/T1")
+        header, spacer = MagicMock(), MagicMock()
+
+        table1 = MagicMock()
+        table1.find_elements.return_value = [header, spacer, row]
+
+        table2 = MagicMock()
+        table2.find_elements.return_value = [header, spacer,
+                                             _make_row(pdf_href="https://collin.tx.publicsearch.us/doc/T2")]
+
+        driver = MagicMock()
+        driver.find_element.return_value = _elem("1-50 of 100 results")
+        driver.find_elements.return_value = [table1, table2]
+
+        records = extract_page_data(driver)
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]["pdf_url"], "https://collin.tx.publicsearch.us/doc/T1")
+
+
+# ---------------------------------------------------------------------------
+# scrape_all
+# ---------------------------------------------------------------------------
+
+class TestScrapeAll(unittest.TestCase):
+
+    @patch("scraper.dynamo")
+    @patch("scraper.extract_page_data")
+    @patch("scraper.load_page", return_value=True)
+    @patch("scraper.initialize_driver")
+    def test_scrapes_only_one_page(self, mock_init, mock_load, mock_extract, mock_dynamo):
+        driver = MagicMock()
+        mock_init.return_value = driver
+        mock_extract.return_value = [{"doc_number": "1", "pdf_url": None}]
+        mock_dynamo.write_records.return_value = 1
+
+        with patch.dict(os.environ, {"DYNAMO_TABLE_NAME": "leads"}):
+            scrape_all("run-001", "CollinTx")
+
+        # load_page called exactly once (first page only)
+        mock_load.assert_called_once()
+        # extract_page_data called exactly once
+        mock_extract.assert_called_once_with(driver)
+
+    @patch("scraper.dynamo")
+    @patch("scraper.extract_page_data")
+    @patch("scraper.load_page", return_value=True)
+    @patch("scraper.initialize_driver")
+    def test_adds_page_number_and_offset_to_records(
+        self, mock_init, mock_load, mock_extract, mock_dynamo
+    ):
+        driver = MagicMock()
+        mock_init.return_value = driver
+        record = {"doc_number": "X", "pdf_url": None}
+        mock_extract.return_value = [record]
+        mock_dynamo.write_records.return_value = 1
+
+        with patch.dict(os.environ, {"DYNAMO_TABLE_NAME": "leads"}):
+            scrape_all("run-002", "CollinTx")
+
+        written_records = mock_dynamo.write_records.call_args[0][0]
+        self.assertEqual(written_records[0]["page_number"], 1)
+        self.assertEqual(written_records[0]["offset"], 0)
+
+    @patch("scraper.load_page", return_value=False)
+    @patch("scraper.initialize_driver")
+    def test_returns_zero_when_page_fails_to_load(self, mock_init, mock_load):
+        mock_init.return_value = MagicMock()
+        with patch.dict(os.environ, {"DYNAMO_TABLE_NAME": "leads"}):
+            result = scrape_all("run-003", "CollinTx")
+        self.assertEqual(result, 0)
+
+    @patch("scraper.dynamo")
+    @patch("scraper.extract_page_data", return_value=[])
+    @patch("scraper.load_page", return_value=True)
+    @patch("scraper.initialize_driver")
+    def test_returns_zero_when_no_records_extracted(
+        self, mock_init, mock_load, mock_extract, mock_dynamo
+    ):
+        mock_init.return_value = MagicMock()
+        with patch.dict(os.environ, {"DYNAMO_TABLE_NAME": "leads"}):
+            result = scrape_all("run-004", "CollinTx")
+        self.assertEqual(result, 0)
+        mock_dynamo.write_records.assert_not_called()
+
+    @patch("scraper.dynamo")
+    @patch("scraper.extract_page_data")
+    @patch("scraper.load_page", return_value=True)
+    @patch("scraper.initialize_driver")
+    def test_driver_always_quit(self, mock_init, mock_load, mock_extract, mock_dynamo):
+        """WebDriver must be closed even if extract_page_data raises."""
+        driver = MagicMock()
+        mock_init.return_value = driver
+        mock_extract.side_effect = RuntimeError("unexpected")
+
+        with patch.dict(os.environ, {"DYNAMO_TABLE_NAME": "leads"}):
+            with self.assertRaises(RuntimeError):
+                scrape_all("run-005", "CollinTx")
+
+        driver.quit.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Scraper changes (src/scraper/scraper.py):
- scrape_all() now scrapes only the first page (most-recent records, sorted descending by recorded date) instead of paginating indefinitely
- get_pdf_url_from_row(row) — checks the row for an inline document link using ROW_PDF_SELECTORS (a[href*="/doc/"] etc.)
- get_pdf_url_by_clicking(driver, row) — clicks the row, waits for the detail panel using DETAIL_PANEL_SELECTORS, extracts the document link from the panel, then dismisses it with Escape
- get_pdf_url(driver, row) — orchestrates both strategies; inline first, click fallback second
- extract_page_data() adds pdf_url to every record dict

Tests (tests/test_scraper.py — 30 new tests, 106 total):
- TestBuildSearchUrl — URL construction and param immutability
- TestGetTotalResults — parsing, missing element, unparseable text
- TestGetPdfUrlFromRow — inline link present/absent/empty href
- TestGetPdfUrlByClicking — panel found/not found, link in panel, Escape key dismissal
- TestGetPdfUrl — inline preferred, click fallback, both fail
- TestExtractPageData — inline PDF, click PDF, record_number/extracted_at, empty table, header skip, multiple rows, row error skip, first-table stop
- TestScrapeAll — single page only, page_number/offset stamped, load failure, no records, driver always quit

Fixtures (tests/fixtures/scraper_html.py):
- MOCK_PAGE_HTML — minimal HTML matching the live CSS selector structure
- ROW_WITH_PDF / ROW_WITHOUT_PDF_INLINE — expected parsed values

Makefile:
- get-api-key uses CloudFormation describe-stack-resources to find the physical API key ID reliably instead of --name-query