### PR TITLE
Make from_date/to_date optional; no dates returns most-recent leads

### DIFF
--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -175,9 +175,10 @@ def test_leads() -> None:
     r = get("/no-such-county/leads", params={"from_date": from_date})
     check("GET /no-such-county/leads → 404", r.status_code == 404, _snippet(r))
 
-    # missing from_date → 400
+    # no date params → most recent leads (200)
     r = get("/collin-tx/leads")
-    check("GET /collin-tx/leads (no from_date) → 400", r.status_code == 400, _snippet(r))
+    if check("GET /collin-tx/leads (no dates) → 200", r.status_code == 200, _snippet(r)):
+        check("no-date response has 'leads' array", "leads" in r.json())
 
 
 # ---------------------------------------------------------------------------

--- a/src/api/routers/leads.py
+++ b/src/api/routers/leads.py
@@ -5,13 +5,11 @@ Queries the location-date-index GSI and returns paginated probate leads
 for the requested county.
 """
 
-import json
 import uuid
 from datetime import datetime, timezone
 
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.event_handler.api_gateway import Router
-from aws_lambda_powertools.event_handler import Response
 from boto3.dynamodb.conditions import Attr, Key
 
 import db
@@ -52,7 +50,7 @@ def get_leads_by_location(location_path: str):
     qs = router.current_event.query_string_parameters or {}
 
     raw_from = qs.get("from_date", "")
-    raw_to   = qs.get("to_date", datetime.now(timezone.utc).strftime("%Y-%m-%d"))
+    raw_to   = qs.get("to_date", "")
     doc_type = qs.get("doc_type", "PROBATE")
 
     try:
@@ -62,12 +60,12 @@ def get_leads_by_location(location_path: str):
         return {"error": "'limit' must be an integer between 1 and 200"}, 400
 
     from_date = parse_date(raw_from) if raw_from else None
-    to_date   = parse_date(raw_to)
+    to_date   = parse_date(raw_to)   if raw_to   else None
 
-    if raw_to and to_date is None:
-        return {"error": f"'to_date' must be YYYY-MM-DD, got: {raw_to!r}"}, 400
     if raw_from and from_date is None:
         return {"error": f"'from_date' must be YYYY-MM-DD, got: {raw_from!r}"}, 400
+    if raw_to and to_date is None:
+        return {"error": f"'to_date' must be YYYY-MM-DD, got: {raw_to!r}"}, 400
 
     last_key = None
     if qs.get("last_key"):
@@ -75,24 +73,24 @@ def get_leads_by_location(location_path: str):
         if last_key is None:
             return {"error": "'last_key' is not a valid pagination cursor"}, 400
 
-    response_headers = {}
-
-    # 2. Build key condition expression for the location-date GSI
+    # 2. Build key condition expression for the location-date GSI.
+    # Both dates optional; no dates → most-recent-first via ScanIndexForward=False.
     if from_date and to_date:
         kce = (
             Key("location_code").eq(location_code)
             & Key("recorded_date").between(from_date, to_date)
         )
-    elif to_date and not from_date:
+    elif from_date:
+        kce = (
+            Key("location_code").eq(location_code)
+            & Key("recorded_date").gte(from_date)
+        )
+    elif to_date:
         kce = (
             Key("location_code").eq(location_code)
             & Key("recorded_date").lte(to_date)
         )
     else:
-        response_headers["X-Warning"] = (
-            "Broad index query in progress. "
-            "Provide from_date and/or to_date for efficient queries."
-        )
         kce = Key("location_code").eq(location_code)
 
     query_kwargs = {
@@ -131,13 +129,5 @@ def get_leads_by_location(location_path: str):
             "limit": limit,
         },
     }
-
-    if response_headers:
-        return Response(
-            status_code=200,
-            content_type="application/json",
-            body=json.dumps(body, default=str),
-            headers=response_headers,
-        )
 
     return body

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -218,6 +218,38 @@ class TestHandlerToDateOnly(unittest.TestCase):
         self.assertIsNone(_body(resp)["query"]["fromDate"])
 
 
+class TestHandlerNoDates(unittest.TestCase):
+    """GSI query with no date params — returns most-recent leads."""
+
+    def setUp(self):
+        self.mock_table     = MagicMock()
+        self.mock_loc_table = MagicMock()
+        db.table           = self.mock_table
+        db.locations_table = self.mock_loc_table
+        self.mock_loc_table.query.return_value = {"Items": [COLLIN_TX]}
+        self.mock_table.query.return_value     = {"Items": MOCK_LEADS}
+
+    def test_returns_200(self):
+        resp = _call({})
+        self.assertEqual(resp["statusCode"], 200)
+
+    def test_uses_query_not_scan(self):
+        _call({})
+        self.mock_table.query.assert_called_once()
+        self.mock_table.scan.assert_not_called()
+
+    def test_sorted_descending(self):
+        _call({})
+        kwargs = self.mock_table.query.call_args[1]
+        self.assertFalse(kwargs["ScanIndexForward"])
+
+    def test_both_dates_none_in_response(self):
+        resp = _call({})
+        body = _body(resp)
+        self.assertIsNone(body["query"]["fromDate"])
+        self.assertIsNone(body["query"]["toDate"])
+
+
 class TestHandlerLimit(unittest.TestCase):
     """Limit parameter handling."""
 
@@ -266,7 +298,7 @@ class TestHandlerDateValidation(unittest.TestCase):
         self.assertIn("from_date", _body(resp)["error"])
 
     def test_invalid_to_date_returns_400(self):
-        resp = _call({"to_date": "20/02/2026"})
+        resp = _call({"from_date": "2026-01-01", "to_date": "20/02/2026"})
         self.assertEqual(resp["statusCode"], 400)
         self.assertIn("to_date", _body(resp)["error"])
 


### PR DESCRIPTION
Both query params are now optional:
  - from_date + to_date  → BETWEEN range
  - from_date only       → gte lower bound
  - to_date only         → lte upper bound
  - neither              → full location scan, ScanIndexForward=False (most recent first)

Update smoke test: no-date GET /leads now expects 200 + leads array. Add TestHandlerNoDates unit tests; restore TestHandlerToDateOnly.