### PR TITLE
Add requests to scraper requirements — fixes ModuleNotFoundError

### DIFF
--- a/src/scraper/requirements.txt
+++ b/src/scraper/requirements.txt
@@ -1,2 +1,3 @@
 selenium>=4.15.0
 boto3>=1.34.0
+requests>=2.31.0


### PR DESCRIPTION
## Summary
- `s3.py` imports `requests` but it was absent from `requirements.txt`
- This caused the ECS container to crash on startup with `ModuleNotFoundError: No module named 'requests'`

## Test plan
- [ ] Rebuild and push the scraper image (`make build-push`)
- [ ] Trigger a scrape task and confirm the container starts without import errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)