### PR TITLE
Require integer doc_number; add db reset targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ STACK_NAME   := probate-scraper-collin-tx
 
 .PHONY: help ecr-create ecr-login build push build-push sam-build deploy \
         run-task logs-scraper logs-api get-api-key invoke-trigger invoke-api \
-        vpc-info local-db-start local-db-stop local-db-seed local-db-shell \
-        local-api-start local-scraper-run test smoke-test
+        vpc-info local-db-start local-db-stop local-db-seed local-db-reset local-db-shell \
+        aws-db-reset local-api-start local-scraper-run test smoke-test
 
 LOCAL_DYNAMO_URL := http://localhost:8000
 LOCAL_ENV        := AWS_ENDPOINT_URL=$(LOCAL_DYNAMO_URL) AWS_DEFAULT_REGION=us-east-1 \
@@ -193,6 +193,19 @@ local-db-stop:
 
 local-db-seed:
 	$(LOCAL_ENV) pipenv run python3 scripts/seed_local.py
+
+local-db-reset:
+	@echo "Dropping and recreating 'leads' table in DynamoDB Local..."
+	-$(LOCAL_ENV) aws dynamodb delete-table --table-name leads \
+		--endpoint-url $(LOCAL_DYNAMO_URL) > /dev/null 2>&1
+	@sleep 1
+	$(LOCAL_ENV) pipenv run python3 scripts/seed_local.py
+	@echo "Reset complete."
+
+aws-db-reset:
+	@echo "Deleting all items from production 'leads' table..."
+	pipenv run python3 scripts/reset_leads.py
+	@echo "Reset complete."
 
 local-db-shell:
 	$(LOCAL_ENV) aws dynamodb scan \

--- a/scripts/reset_leads.py
+++ b/scripts/reset_leads.py
@@ -1,0 +1,62 @@
+"""
+reset_leads.py — delete every item from the leads table.
+
+Works against both DynamoDB Local and production AWS depending on env vars.
+
+Local:
+    make local-db-reset          # preferred (drops + recreates the table)
+    # or directly:
+    AWS_ENDPOINT_URL=http://localhost:8000 AWS_DEFAULT_REGION=us-east-1 \
+    AWS_ACCESS_KEY_ID=local AWS_SECRET_ACCESS_KEY=local \
+    pipenv run python3 scripts/reset_leads.py
+
+Production:
+    make aws-db-reset
+    # or directly:
+    pipenv run python3 scripts/reset_leads.py
+"""
+
+import os
+import boto3
+
+ENDPOINT   = os.environ.get("AWS_ENDPOINT_URL")
+TABLE_NAME = os.environ.get("DYNAMO_TABLE_NAME", "leads")
+REGION     = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
+
+session = boto3.Session(
+    aws_access_key_id=os.environ.get("AWS_ACCESS_KEY_ID"),
+    aws_secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY"),
+    region_name=REGION,
+)
+kwargs = {"endpoint_url": ENDPOINT} if ENDPOINT else {}
+ddb = session.client("dynamodb", **kwargs)
+
+print(f"Scanning '{TABLE_NAME}' for all doc_number keys...")
+
+paginator = ddb.get_paginator("scan")
+delete_requests = []
+
+for page in paginator.paginate(
+    TableName=TABLE_NAME,
+    ProjectionExpression="doc_number",
+):
+    for item in page.get("Items", []):
+        delete_requests.append(
+            {"DeleteRequest": {"Key": {"doc_number": item["doc_number"]}}}
+        )
+
+if not delete_requests:
+    print("Table is already empty.")
+else:
+    total = len(delete_requests)
+    print(f"  Deleting {total} item(s) in batches of 25...")
+    deleted = 0
+    for i in range(0, total, 25):
+        chunk = delete_requests[i : i + 25]
+        resp = ddb.batch_write_item(RequestItems={TABLE_NAME: chunk})
+        unprocessed = resp.get("UnprocessedItems", {}).get(TABLE_NAME, [])
+        deleted += len(chunk) - len(unprocessed)
+        if unprocessed:
+            print(f"  WARNING: {len(unprocessed)} items not deleted in batch {i // 25}")
+
+    print(f"  {deleted}/{total} items deleted from '{TABLE_NAME}'.")

--- a/src/scraper/dynamo.py
+++ b/src/scraper/dynamo.py
@@ -108,7 +108,7 @@ def write_records(
     put_requests = [
         {"PutRequest": {"Item": _to_dynamo_item(r, scrape_run_id, location_code)}}
         for r in records
-        if r.get("doc_number") and r["doc_number"] != "N/A"
+        if str(r.get("doc_number", "")).strip().isdigit()
     ]
 
     total_written = 0

--- a/src/scraper/scraper.py
+++ b/src/scraper/scraper.py
@@ -752,7 +752,7 @@ def scrape_all(scrape_run_id: str, location_code: str):
         for rec in page_records:
             local_path = rec.get("doc_local_path") or ""
             doc_number = rec.get("doc_number") or ""
-            if local_path and doc_number and doc_number not in ("N/A", "UNKNOWN"):
+            if local_path and doc_number.strip().isdigit():
                 rec["doc_local_path"] = _rename_download(
                     local_path, doc_number, _used_download_names
                 )

--- a/tests/test_dynamo.py
+++ b/tests/test_dynamo.py
@@ -1,0 +1,160 @@
+"""
+Unit tests for src/scraper/dynamo.py
+
+Covers:
+  - normalize_date()
+  - write_records() integer doc_number filter
+  - write_records() DynamoDB batch chunking and retry
+  - update_location_retrieved_at()
+"""
+
+import sys
+import os
+import unittest
+from unittest.mock import MagicMock, patch, call
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src", "scraper"))
+
+import dynamo
+
+
+# ---------------------------------------------------------------------------
+# normalize_date
+# ---------------------------------------------------------------------------
+
+class TestNormalizeDate(unittest.TestCase):
+
+    def test_converts_m_d_yyyy(self):
+        self.assertEqual(dynamo.normalize_date("1/23/2026"), "2026-01-23")
+
+    def test_pads_single_digit_month_and_day(self):
+        self.assertEqual(dynamo.normalize_date("11/7/2025"), "2025-11-07")
+
+    def test_passthrough_na(self):
+        self.assertEqual(dynamo.normalize_date("N/A"), "N/A")
+
+    def test_passthrough_empty(self):
+        self.assertEqual(dynamo.normalize_date(""), "")
+
+    def test_passthrough_dashes(self):
+        self.assertEqual(dynamo.normalize_date("--/--/--"), "--/--/--")
+
+    def test_passthrough_unrecognised(self):
+        self.assertEqual(dynamo.normalize_date("2026-01-23"), "2026-01-23")
+
+
+# ---------------------------------------------------------------------------
+# write_records — integer doc_number filter
+# ---------------------------------------------------------------------------
+
+def _make_record(doc_number: str) -> dict:
+    return {
+        "doc_number":        doc_number,
+        "grantor":           "Smith, John",
+        "grantee":           "Jones, Mary",
+        "doc_type":          "PROBATE",
+        "recorded_date":     "2026-01-23",
+        "book_volume_page":  "N/A",
+        "legal_description": "Lot 1",
+        "pdf_url":           "",
+        "doc_local_path":    "",
+        "doc_s3_uri":        "",
+    }
+
+
+class TestWriteRecordsIntegerFilter(unittest.TestCase):
+    """write_records must only write records whose doc_number is a digit string."""
+
+    def _run_write(self, records):
+        """Call write_records with a mocked DynamoDB client; return captured put requests."""
+        captured = []
+
+        def fake_batch_write(RequestItems):
+            for req in RequestItems.get("leads", []):
+                captured.append(req)
+            return {"UnprocessedItems": {}}
+
+        with patch.object(dynamo._dynamodb, "batch_write_item", side_effect=fake_batch_write):
+            dynamo.write_records(records, "leads", "run-test", "CollinTx")
+
+        return captured
+
+    def test_integer_doc_number_is_written(self):
+        records = [_make_record("20240001234")]
+        written = self._run_write(records)
+        self.assertEqual(len(written), 1)
+
+    def test_na_doc_number_is_filtered_out(self):
+        records = [_make_record("N/A")]
+        written = self._run_write(records)
+        self.assertEqual(len(written), 0)
+
+    def test_unknown_doc_number_is_filtered_out(self):
+        records = [_make_record("UNKNOWN")]
+        written = self._run_write(records)
+        self.assertEqual(len(written), 0)
+
+    def test_alphanumeric_doc_number_is_filtered_out(self):
+        records = [_make_record("DOC123")]
+        written = self._run_write(records)
+        self.assertEqual(len(written), 0)
+
+    def test_empty_doc_number_is_filtered_out(self):
+        records = [_make_record("")]
+        written = self._run_write(records)
+        self.assertEqual(len(written), 0)
+
+    def test_mixed_records_only_integers_written(self):
+        records = [
+            _make_record("20240001"),
+            _make_record("N/A"),
+            _make_record("20240002"),
+            _make_record("DOC99"),
+            _make_record("20240003"),
+        ]
+        written = self._run_write(records)
+        self.assertEqual(len(written), 3)
+
+    def test_empty_records_list_returns_zero(self):
+        result = dynamo.write_records([], "leads", "run-empty", "CollinTx")
+        self.assertEqual(result, 0)
+
+
+# ---------------------------------------------------------------------------
+# write_records — batch chunking
+# ---------------------------------------------------------------------------
+
+class TestWriteRecordsBatching(unittest.TestCase):
+
+    def test_batches_in_chunks_of_25(self):
+        records = [_make_record(str(i)) for i in range(60)]
+        batch_calls = []
+
+        def fake_batch_write(RequestItems):
+            batch_calls.append(len(RequestItems.get("leads", [])))
+            return {"UnprocessedItems": {}}
+
+        with patch.object(dynamo._dynamodb, "batch_write_item", side_effect=fake_batch_write):
+            dynamo.write_records(records, "leads", "run-batch", "CollinTx")
+
+        self.assertEqual(batch_calls, [25, 25, 10])
+
+    def test_retries_unprocessed_items(self):
+        records = [_make_record("1"), _make_record("2")]
+        call_count = [0]
+
+        def fake_batch_write(RequestItems):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                # Return one item as unprocessed on the first call
+                return {"UnprocessedItems": {"leads": [{"PutRequest": {"Item": {}}}]}}
+            return {"UnprocessedItems": {}}
+
+        with patch.object(dynamo._dynamodb, "batch_write_item", side_effect=fake_batch_write):
+            dynamo.write_records(records, "leads", "run-retry", "CollinTx")
+
+        self.assertEqual(call_count[0], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -934,6 +934,53 @@ class TestScrapeAll(unittest.TestCase):
         driver.quit.assert_called_once()
 
 
+    @patch("scraper._rename_download")
+    @patch("scraper.login", return_value=True)
+    @patch("scraper.dynamo")
+    @patch("scraper.extract_page_data")
+    @patch("scraper.load_page", return_value=True)
+    @patch("scraper.initialize_driver")
+    def test_rename_called_when_doc_number_is_integer(
+        self, mock_init, mock_load, mock_extract, mock_dynamo, mock_login, mock_rename
+    ):
+        """_rename_download is called when doc_number is a valid integer string."""
+        mock_init.return_value = MagicMock()
+        mock_extract.return_value = [
+            {"doc_number": "20240001234", "pdf_url": None, "doc_local_path": "/tmp/file.pdf"},
+        ]
+        mock_dynamo.write_records.return_value = 1
+        mock_rename.return_value = "/tmp/20240001234.pdf"
+
+        with patch.dict(os.environ, {"DYNAMO_TABLE_NAME": "leads"}):
+            scrape_all("run-rename-01", "CollinTx")
+
+        mock_rename.assert_called_once()
+        call_args = mock_rename.call_args[0]
+        self.assertEqual(call_args[0], "/tmp/file.pdf")
+        self.assertEqual(call_args[1], "20240001234")
+
+    @patch("scraper._rename_download")
+    @patch("scraper.login", return_value=True)
+    @patch("scraper.dynamo")
+    @patch("scraper.extract_page_data")
+    @patch("scraper.load_page", return_value=True)
+    @patch("scraper.initialize_driver")
+    def test_rename_skipped_when_doc_number_not_integer(
+        self, mock_init, mock_load, mock_extract, mock_dynamo, mock_login, mock_rename
+    ):
+        """_rename_download is NOT called when doc_number is non-numeric (e.g. 'N/A')."""
+        mock_init.return_value = MagicMock()
+        mock_extract.return_value = [
+            {"doc_number": "N/A", "pdf_url": None, "doc_local_path": "/tmp/N-A.pdf"},
+        ]
+        mock_dynamo.write_records.return_value = 0
+
+        with patch.dict(os.environ, {"DYNAMO_TABLE_NAME": "leads"}):
+            scrape_all("run-rename-02", "CollinTx")
+
+        mock_rename.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # scrape_all — S3 upload integration
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **Integer doc_number validation**: `write_records` now uses `.isdigit()` to filter records — only numeric doc numbers (e.g. `20240001234`) are written to DynamoDB. Non-numeric values like `N/A`, `UNKNOWN`, `DOC99` are silently dropped.
- **Rename guard**: `scrape_all` applies the same `.isdigit()` check before renaming a downloaded file, so a failed selector can never produce `N-A.pdf`
- **`make local-db-reset`**: drops and recreates the local `leads` table (clears all scrape data, preserves locations/subscribers)
- **`make aws-db-reset`**: scans and batch-deletes all items from the production `leads` table via `scripts/reset_leads.py`

## Test plan
- [ ] 192 tests passing (`make test`)
- [ ] `make local-db-reset` drops and re-seeds the local leads table cleanly
- [ ] After a scrape run with valid credentials, confirm docs are named `{integer}.pdf` not `N-A.pdf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)