### PR TITLE
Fix N-A.pdf: guard S3 upload with isdigit(); add selector fallbacks + HTML debug log

### DIFF
--- a/src/scraper/scraper.py
+++ b/src/scraper/scraper.py
@@ -678,11 +678,23 @@ def extract_page_data(driver, download_dir: str = "", max_downloads: int = 1):
         log.info("Processing table with %d rows", len(rows))
         for i, row in enumerate(rows[2:], start=1):
             try:
-                def _text(sel):
+                def _text(*selectors):
+                    """Try each selector in order; return the first non-empty match."""
+                    for sel in selectors:
+                        try:
+                            text = row.find_element(By.CSS_SELECTOR, sel).text.strip()
+                            if text:
+                                return text
+                        except Exception:
+                            continue
+                    return "N/A"
+
+                # Dump the first data row's HTML so we can diagnose selector mismatches
+                if i == 1:
                     try:
-                        return row.find_element(By.CSS_SELECTOR, sel).text.strip()
+                        log.info("First row HTML: %s", row.get_attribute("outerHTML")[:3000])
                     except Exception:
-                        return "N/A"
+                        pass
 
                 if i <= max_downloads:
                     pdf_url, local_path = get_pdf_url(driver, row, download_dir)
@@ -692,12 +704,12 @@ def extract_page_data(driver, download_dir: str = "", max_downloads: int = 1):
                     local_path = None
 
                 record = {
-                    "grantor":           _text('td.col-3[column="[object Object]"] span'),
-                    "grantee":           _text('td.col-4[column="[object Object]"] span'),
-                    "doc_type":          _text('td.col-5[column="[object Object]"] span em'),
-                    "recorded_date":     _text('td.col-6[column="[object Object]"] span'),
-                    "doc_number":        _text('td.col-7[column="[object Object]"] span'),
-                    "book_volume_page":  _text('td.col-8[column="[object Object]"] span'),
+                    "grantor":           _text('td.col-3[column="[object Object]"] span', 'td.col-3 span'),
+                    "grantee":           _text('td.col-4[column="[object Object]"] span', 'td.col-4 span'),
+                    "doc_type":          _text('td.col-5[column="[object Object]"] span em', 'td.col-5 span em', 'td.col-5 span'),
+                    "recorded_date":     _text('td.col-6[column="[object Object]"] span', 'td.col-6 span'),
+                    "doc_number":        _text('td.col-7[column="[object Object]"] span', 'td.col-7 span'),
+                    "book_volume_page":  _text('td.col-8[column="[object Object]"] span', 'td.col-8 span'),
                     "legal_description": _text("td.col-9"),
                     "pdf_url":           pdf_url,
                     "doc_local_path":    local_path or "",
@@ -763,7 +775,7 @@ def scrape_all(scrape_run_id: str, location_code: str):
             rec["page_number"] = 1
             rec["offset"] = 0
 
-            if bucket and rec.get("doc_number"):
+            if bucket and str(rec.get("doc_number", "")).strip().isdigit():
                 local_path = rec.get("doc_local_path") or ""
                 if local_path and os.path.isfile(local_path):
                     rec["doc_s3_uri"] = s3_helper.upload_local_file(

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -1008,11 +1008,11 @@ class TestScrapeAllWithS3(unittest.TestCase):
         driver = MagicMock()
         mock_init.return_value = driver
         mock_extract.return_value = [
-            {"doc_number": "DOC1", "pdf_url": "https://site.com/doc/DOC1", "doc_local_path": ""},
-            {"doc_number": "DOC2", "pdf_url": "https://site.com/doc/DOC2", "doc_local_path": ""},
+            {"doc_number": "20240001", "pdf_url": "https://site.com/doc/20240001", "doc_local_path": ""},
+            {"doc_number": "20240002", "pdf_url": "https://site.com/doc/20240002", "doc_local_path": ""},
         ]
         mock_dynamo.write_records.return_value = 2
-        scraper.s3_helper.fetch_and_upload.return_value = "s3://bucket/documents/CollinTx/DOC1.pdf"
+        scraper.s3_helper.fetch_and_upload.return_value = "s3://bucket/documents/CollinTx/20240001.pdf"
 
         with patch.dict(os.environ, {"DYNAMO_TABLE_NAME": "leads",
                                      "DOCUMENTS_BUCKET": "my-bucket"}):
@@ -1035,13 +1035,13 @@ class TestScrapeAllWithS3(unittest.TestCase):
         mock_init.return_value = driver
         mock_extract.return_value = [
             {
-                "doc_number": "DOC1",
-                "pdf_url": "https://site.com/doc/DOC1",
+                "doc_number": "20240001",
+                "pdf_url": "https://site.com/doc/20240001",
                 "doc_local_path": "/tmp/20240001.pdf",
             },
         ]
         mock_dynamo.write_records.return_value = 1
-        scraper.s3_helper.upload_local_file.return_value = "s3://bucket/documents/CollinTx/DOC1.pdf"
+        scraper.s3_helper.upload_local_file.return_value = "s3://bucket/documents/CollinTx/20240001.pdf"
 
         with patch.dict(os.environ, {"DYNAMO_TABLE_NAME": "leads",
                                      "DOCUMENTS_BUCKET": "my-bucket"}):
@@ -1086,7 +1086,7 @@ class TestScrapeAllWithS3(unittest.TestCase):
         driver = MagicMock()
         mock_init.return_value = driver
         mock_extract.return_value = [
-            {"doc_number": "DOC1", "pdf_url": None, "doc_local_path": ""},
+            {"doc_number": "20240001", "pdf_url": None, "doc_local_path": ""},
         ]
         mock_dynamo.write_records.return_value = 1
 
@@ -1108,10 +1108,10 @@ class TestScrapeAllWithS3(unittest.TestCase):
         """The S3 URI returned by fetch_and_upload must appear on the written record."""
         driver = MagicMock()
         mock_init.return_value = driver
-        record = {"doc_number": "DOC99", "pdf_url": "https://site.com/doc/DOC99", "doc_local_path": ""}
+        record = {"doc_number": "20240099", "pdf_url": "https://site.com/doc/20240099", "doc_local_path": ""}
         mock_extract.return_value = [record]
         mock_dynamo.write_records.return_value = 1
-        scraper.s3_helper.fetch_and_upload.return_value = "s3://my-bucket/documents/CollinTx/DOC99.pdf"
+        scraper.s3_helper.fetch_and_upload.return_value = "s3://my-bucket/documents/CollinTx/20240099.pdf"
 
         with patch.dict(os.environ, {"DYNAMO_TABLE_NAME": "leads",
                                      "DOCUMENTS_BUCKET": "my-bucket"}):
@@ -1119,7 +1119,7 @@ class TestScrapeAllWithS3(unittest.TestCase):
 
         written = mock_dynamo.write_records.call_args[0][0]
         self.assertEqual(written[0]["doc_s3_uri"],
-                         "s3://my-bucket/documents/CollinTx/DOC99.pdf")
+                         "s3://my-bucket/documents/CollinTx/20240099.pdf")
 
     @patch("scraper.login", return_value=True)
     @patch("scraper.dynamo")
@@ -1134,7 +1134,7 @@ class TestScrapeAllWithS3(unittest.TestCase):
         driver.get_cookies.return_value = [{"name": "sess", "value": "tok123"}]
         mock_init.return_value = driver
         mock_extract.return_value = [
-            {"doc_number": "DOC1", "pdf_url": "https://site.com/doc/DOC1", "doc_local_path": ""},
+            {"doc_number": "20240001", "pdf_url": "https://site.com/doc/20240001", "doc_local_path": ""},
         ]
         mock_dynamo.write_records.return_value = 1
         scraper.s3_helper.fetch_and_upload.return_value = "s3://b/k.pdf"
@@ -1151,6 +1151,29 @@ class TestScrapeAllWithS3(unittest.TestCase):
     @patch("scraper.extract_page_data")
     @patch("scraper.load_page", return_value=True)
     @patch("scraper.initialize_driver")
+    def test_s3_upload_skipped_when_doc_number_not_integer(
+        self, mock_init, mock_load, mock_extract, mock_dynamo, mock_login
+    ):
+        """S3 upload must be skipped when doc_number is non-numeric (e.g. 'N/A')."""
+        driver = MagicMock()
+        mock_init.return_value = driver
+        mock_extract.return_value = [
+            {"doc_number": "N/A", "pdf_url": "https://site.com/doc/1", "doc_local_path": "/tmp/N-A.pdf"},
+        ]
+        mock_dynamo.write_records.return_value = 0
+
+        with patch.dict(os.environ, {"DYNAMO_TABLE_NAME": "leads",
+                                     "DOCUMENTS_BUCKET": "my-bucket"}):
+            scrape_all("run-s3-noint", "CollinTx")
+
+        scraper.s3_helper.upload_local_file.assert_not_called()
+        scraper.s3_helper.fetch_and_upload.assert_not_called()
+
+    @patch("scraper.login", return_value=True)
+    @patch("scraper.dynamo")
+    @patch("scraper.extract_page_data")
+    @patch("scraper.load_page", return_value=True)
+    @patch("scraper.initialize_driver")
     def test_upload_failure_does_not_abort_scrape(
         self, mock_init, mock_load, mock_extract, mock_dynamo, mock_login
     ):
@@ -1158,8 +1181,8 @@ class TestScrapeAllWithS3(unittest.TestCase):
         driver = MagicMock()
         mock_init.return_value = driver
         mock_extract.return_value = [
-            {"doc_number": "DOC1", "pdf_url": "https://site.com/doc/DOC1", "doc_local_path": ""},
-            {"doc_number": "DOC2", "pdf_url": "https://site.com/doc/DOC2", "doc_local_path": ""},
+            {"doc_number": "20240001", "pdf_url": "https://site.com/doc/20240001", "doc_local_path": ""},
+            {"doc_number": "20240002", "pdf_url": "https://site.com/doc/20240002", "doc_local_path": ""},
         ]
         mock_dynamo.write_records.return_value = 2
         scraper.s3_helper.fetch_and_upload.return_value = None  # all uploads fail


### PR DESCRIPTION
## Root causes
Two bugs identified from ECS logs:

**Bug 1 — Wrong S3 guard**
`if bucket and rec.get("doc_number")` is truthy for `"N/A"`, so documents were uploaded as `N-A.pdf`. Now uses `.isdigit()` — same guard as `write_records` and the rename step.

**Bug 2 — CSS selectors not matching**
`td.col-N[column="[object Object]"] span` works when logged out but may not match when logged in (column attribute may differ). `_text()` now accepts multiple selectors and tries each in order, falling back to `td.col-N span` without the attribute filter.

## Observability
First data row's `outerHTML` (up to 3000 chars) is now logged at INFO on every run — next ECS log will show exactly what the DOM looks like so we can confirm which selectors match or tune them further.

## Test plan
- [ ] 193 tests passing (`make test`)
- [ ] Trigger a scrape and check ECS logs for `First row HTML:` — confirms selectors are now working
- [ ] No more `N-A.pdf` uploads to S3
- [ ] `Wrote N/N records` shows a non-zero count

🤖 Generated with [Claude Code](https://claude.com/claude-code)