### PR TITLE
Fix stale WebElement references — extract text before clicking row

### DIFF
--- a/src/scraper/scraper.py
+++ b/src/scraper/scraper.py
@@ -675,51 +675,85 @@ def extract_page_data(driver, download_dir: str = "", max_downloads: int = 1):
         if len(rows) <= 2:
             continue
 
+        data_rows = rows[2:]
         log.info("Processing table with %d rows", len(rows))
-        for i, row in enumerate(rows[2:], start=1):
+
+        # Log first row HTML to confirm selectors (remove once stable)
+        if data_rows:
             try:
-                def _text(*selectors):
-                    """Try each selector in order; return the first non-empty match."""
+                log.info("First row HTML: %s", data_rows[0].get_attribute("outerHTML")[:3000])
+            except Exception:
+                pass
+
+        # ── Phase 1: extract text + inline links from ALL rows before any click.
+        # Clicking a row to open the detail panel causes React to re-render the
+        # table, staling every captured WebElement reference.  Reading text first
+        # means all 50 rows are scraped while their DOM nodes are still live.
+        extracted = []
+        for i, row in enumerate(data_rows, start=1):
+            try:
+                def _text(*selectors, _row=row):
+                    """Try each selector in order; return first non-empty match."""
                     for sel in selectors:
                         try:
-                            text = row.find_element(By.CSS_SELECTOR, sel).text.strip()
+                            text = _row.find_element(By.CSS_SELECTOR, sel).text.strip()
                             if text:
                                 return text
                         except Exception:
                             continue
                     return "N/A"
 
-                # Dump the first data row's HTML so we can diagnose selector mismatches
-                if i == 1:
-                    try:
-                        log.info("First row HTML: %s", row.get_attribute("outerHTML")[:3000])
-                    except Exception:
-                        pass
-
-                if i <= max_downloads:
-                    pdf_url, local_path = get_pdf_url(driver, row, download_dir)
-                else:
-                    # Inline link only — no panel click
-                    pdf_url = get_pdf_url_from_row(row)
-                    local_path = None
-
-                record = {
+                extracted.append({
+                    "index":             i,
+                    "row":               row,
                     "grantor":           _text('td.col-3[column="[object Object]"] span', 'td.col-3 span'),
                     "grantee":           _text('td.col-4[column="[object Object]"] span', 'td.col-4 span'),
                     "doc_type":          _text('td.col-5[column="[object Object]"] span em', 'td.col-5 span em', 'td.col-5 span'),
                     "recorded_date":     _text('td.col-6[column="[object Object]"] span', 'td.col-6 span'),
                     "doc_number":        _text('td.col-7[column="[object Object]"] span', 'td.col-7 span'),
                     "book_volume_page":  _text('td.col-8[column="[object Object]"] span', 'td.col-8 span'),
-                    "legal_description": _text("td.col-9"),
-                    "pdf_url":           pdf_url,
-                    "doc_local_path":    local_path or "",
-                    "record_number":     i,
-                    "extracted_at":      datetime.utcnow().isoformat(),
-                }
-                records.append(record)
+                    "legal_description": _text('td.col-9 span', 'td.col-9'),
+                    "inline_url":        get_pdf_url_from_row(row),
+                })
             except Exception as exc:
-                log.warning("Row %d extraction error: %s", i, exc)
-                continue
+                log.warning("Row %d text extraction error: %s", i, exc)
+
+        # ── Phase 2: click for download on eligible rows (after all text captured).
+        # The click may re-render the table; that's fine because we're done reading.
+        for entry in extracted:
+            i   = entry["index"]
+            row = entry["row"]
+            if i <= max_downloads:
+                if entry["inline_url"]:
+                    entry["pdf_url"]    = entry["inline_url"]
+                    entry["local_path"] = None
+                else:
+                    try:
+                        pdf_url, local_path = get_pdf_url_by_clicking(driver, row, download_dir)
+                    except Exception as exc:
+                        log.warning("Row %d click error: %s", entry["index"], exc)
+                        pdf_url, local_path = None, None
+                    entry["pdf_url"]    = pdf_url
+                    entry["local_path"] = local_path
+            else:
+                entry["pdf_url"]    = entry["inline_url"]
+                entry["local_path"] = None
+
+        # ── Phase 3: assemble final record dicts
+        for entry in extracted:
+            records.append({
+                "grantor":           entry["grantor"],
+                "grantee":           entry["grantee"],
+                "doc_type":          entry["doc_type"],
+                "recorded_date":     entry["recorded_date"],
+                "doc_number":        entry["doc_number"],
+                "book_volume_page":  entry["book_volume_page"],
+                "legal_description": entry["legal_description"],
+                "pdf_url":           entry.get("pdf_url"),
+                "doc_local_path":    entry.get("local_path") or "",
+                "record_number":     entry["index"],
+                "extracted_at":      datetime.utcnow().isoformat(),
+            })
 
         if records:
             break  # stop at the first table that yielded data

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -548,23 +548,24 @@ class TestExtractPageData(unittest.TestCase):
         self.assertEqual(records[0]["record_number"], 1)
         self.assertEqual(records[1]["record_number"], 2)
 
-    @patch("scraper.get_pdf_url")
-    def test_row_error_does_not_abort_page(self, mock_get_pdf):
+    @patch("scraper.get_pdf_url_by_clicking")
+    def test_row_error_does_not_abort_page(self, mock_click):
         """
-        An unexpected error in the first row (panel-click row) should be
-        skipped; subsequent rows are still extracted via inline-link lookup.
+        An error during the panel-click (Phase 2) must not prevent other rows
+        from being written.  Text extraction (Phase 1) runs before any click,
+        so all rows' text is captured regardless of click failures.
         """
-        # Row 1 (i=1, panel-click row) raises inside get_pdf_url
-        mock_get_pdf.side_effect = Exception("unexpected DOM explosion")
-        # Row 2 (i=2, inline-only) has a direct link so it succeeds without get_pdf_url
+        # Row 1 click raises — click error is caught; row still gets a record with pdf_url=None
+        mock_click.side_effect = Exception("unexpected DOM explosion")
         row1 = _make_row(pdf_href=None)
         row2 = _make_row(pdf_href="https://collin.tx.publicsearch.us/doc/OK")
         driver = _make_driver_with_rows(row1, row2)
 
         records = extract_page_data(driver)
-        # row1 skipped, row2 extracted via its inline link
-        self.assertEqual(len(records), 1)
-        self.assertEqual(records[0]["pdf_url"], "https://collin.tx.publicsearch.us/doc/OK")
+        # Both rows produce records; row1 has pdf_url=None, row2 has its inline link
+        self.assertEqual(len(records), 2)
+        self.assertIsNone(records[0]["pdf_url"])
+        self.assertEqual(records[1]["pdf_url"], "https://collin.tx.publicsearch.us/doc/OK")
 
     @patch("scraper.get_pdf_url_by_clicking", return_value=(None, None))
     def test_download_only_for_first_row(self, mock_click):


### PR DESCRIPTION
## Root cause (confirmed from HTML dump)

The selectors were correct — `col-7` clearly contained `2026000023696`. The bug was **stale element references**: clicking row 1 to open the download panel caused React to re-render the entire table, invalidating all 50 captured `WebElement` references. Every subsequent `row.find_element()` raised `StaleElementReferenceException`, silently caught by `except Exception`, returning `"N/A"` for all fields on all 50 rows.

## Fix: three-phase extraction

| Phase | What happens |
|---|---|
| **1** | Extract text + inline links from **all rows** while DOM is live |
| **2** | Click row 1 for download — re-render is now harmless |
| **3** | Assemble final record dicts |

Also fixes `legal_description` selector to `td.col-9 span` (HTML dump confirmed col-9 wraps content in a `<span>`).

## Test plan
- [ ] 193 tests passing (`make test`)
- [ ] Trigger a scrape — expect `Wrote N/N records` with a non-zero count and correctly named `{doc_number}.pdf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)