### PR TITLE
feat: POST /leads/{lead_id}/parse-document — Bedrock PDF extraction

### DIFF
--- a/src/api/models.py
+++ b/src/api/models.py
@@ -33,59 +33,93 @@ def _normalize_timestamp(ts: str) -> str:
 
 @dataclass
 class Lead:
-    doc_number:        str = ""
-    grantor:           str = ""
-    grantee:           str = ""
-    doc_type:          str = ""
-    recorded_date:     str = ""
-    book_volume_page:  str = ""
-    legal_description: str = ""
-    record_number:     int = 0
-    page_number:       int = 0
-    extracted_at:      str = ""
-    processed_at:      str = ""
-    scrape_run_id:     str = ""
-    location_code:     str = ""
-    offset:            int = 0
-    pdf_url:           str = ""
+    doc_number:            str  = ""
+    grantor:               str  = ""
+    grantee:               str  = ""
+    doc_type:              str  = ""
+    recorded_date:         str  = ""
+    book_volume_page:      str  = ""
+    legal_description:     str  = ""
+    record_number:         int  = 0
+    page_number:           int  = 0
+    extracted_at:          str  = ""
+    processed_at:          str  = ""
+    scrape_run_id:         str  = ""
+    location_code:         str  = ""
+    offset:                int  = 0
+    pdf_url:               str  = ""
+    doc_s3_uri:            str  = ""
+    # --- Parsed fields (populated by ParseDocumentFunction) ------------------
+    parsed_at:             str  = ""
+    parsed_model:          str  = ""
+    deceased_name:         str  = ""
+    deceased_dob:          str  = ""
+    deceased_dod:          str  = ""
+    deceased_last_address: str  = ""
+    people:                list = field(default_factory=list)
+    real_property:         list = field(default_factory=list)
+    summary:               str  = ""
+    parse_error:           str  = ""
 
     @classmethod
     def from_dynamo(cls, item: dict) -> "Lead":
         return cls(
-            doc_number=        item.get("doc_number", ""),
-            grantor=           item.get("grantor", ""),
-            grantee=           item.get("grantee", ""),
-            doc_type=          item.get("doc_type", ""),
-            recorded_date=     item.get("recorded_date", ""),
-            book_volume_page=  item.get("book_volume_page", ""),
-            legal_description= item.get("legal_description", ""),
-            record_number=     int(item.get("record_number", 0) or 0),
-            page_number=       int(item.get("page_number", 0) or 0),
-            extracted_at=      str(item.get("extracted_at", "")),
-            processed_at=      str(item.get("processed_at", "")),
-            scrape_run_id=     item.get("scrape_run_id", ""),
-            location_code=     item.get("location_code", ""),
-            offset=            int(item.get("offset", 0) or 0),
-            pdf_url=           item.get("pdf_url", ""),
+            doc_number=            item.get("doc_number", ""),
+            grantor=               item.get("grantor", ""),
+            grantee=               item.get("grantee", ""),
+            doc_type=              item.get("doc_type", ""),
+            recorded_date=         item.get("recorded_date", ""),
+            book_volume_page=      item.get("book_volume_page", ""),
+            legal_description=     item.get("legal_description", ""),
+            record_number=         int(item.get("record_number", 0) or 0),
+            page_number=           int(item.get("page_number", 0) or 0),
+            extracted_at=          str(item.get("extracted_at", "")),
+            processed_at=          str(item.get("processed_at", "")),
+            scrape_run_id=         item.get("scrape_run_id", ""),
+            location_code=         item.get("location_code", ""),
+            offset=                int(item.get("offset", 0) or 0),
+            pdf_url=               item.get("pdf_url", ""),
+            doc_s3_uri=            item.get("doc_s3_uri", ""),
+            parsed_at=             item.get("parsed_at", ""),
+            parsed_model=          item.get("parsed_model", ""),
+            deceased_name=         item.get("deceased_name", ""),
+            deceased_dob=          item.get("deceased_dob", ""),
+            deceased_dod=          item.get("deceased_dod", ""),
+            deceased_last_address= item.get("deceased_last_address", ""),
+            people=                list(item.get("people", []) or []),
+            real_property=         list(item.get("real_property", []) or []),
+            summary=               item.get("summary", ""),
+            parse_error=           item.get("parse_error", ""),
         )
 
     def to_dict(self) -> dict:
         return {
-            "docNumber":        self.doc_number,
-            "grantor":          self.grantor,
-            "grantee":          self.grantee,
-            "docType":          self.doc_type,
-            "recordedDate":     self.recorded_date,
-            "bookVolumePage":   self.book_volume_page,
-            "legalDescription": self.legal_description,
-            "recordNumber":     self.record_number,
-            "pageNumber":       self.page_number,
-            "extractedAt":      _normalize_timestamp(self.extracted_at),
-            "processedAt":      _normalize_timestamp(self.processed_at),
-            "scrapeRunId":      self.scrape_run_id,
-            "locationCode":     self.location_code,
-            "offset":           self.offset,
-            "pdfUrl":           self.pdf_url,
+            "docNumber":           self.doc_number,
+            "grantor":             self.grantor,
+            "grantee":             self.grantee,
+            "docType":             self.doc_type,
+            "recordedDate":        self.recorded_date,
+            "bookVolumePage":      self.book_volume_page,
+            "legalDescription":    self.legal_description,
+            "recordNumber":        self.record_number,
+            "pageNumber":          self.page_number,
+            "extractedAt":         _normalize_timestamp(self.extracted_at),
+            "processedAt":         _normalize_timestamp(self.processed_at),
+            "scrapeRunId":         self.scrape_run_id,
+            "locationCode":        self.location_code,
+            "offset":              self.offset,
+            "pdfUrl":              self.pdf_url,
+            "docS3Uri":            self.doc_s3_uri,
+            "parsedAt":            _normalize_timestamp(self.parsed_at),
+            "parsedModel":         self.parsed_model,
+            "deceasedName":        self.deceased_name,
+            "deceasedDob":         self.deceased_dob,
+            "deceasedDod":         self.deceased_dod,
+            "deceasedLastAddress": self.deceased_last_address,
+            "people":              self.people,
+            "realProperty":        self.real_property,
+            "summary":             self.summary,
+            "parseError":          self.parse_error,
         }
 
 

--- a/src/parse_document/app.py
+++ b/src/parse_document/app.py
@@ -1,0 +1,224 @@
+"""
+ParseDocumentFunction — Lambda handler.
+
+Route (registered in template.yaml):
+  POST /real-estate/probate-leads/leads/{lead_id}/parse-document
+
+Flow:
+  1. Look up the lead by doc_number (lead_id) in DynamoDB.
+  2. Verify it has a doc_s3_uri pointing to the stored PDF.
+  3. Fetch the PDF bytes from S3.
+  4. Send the PDF to Amazon Bedrock (Claude 3.5 Haiku) via the Converse API
+     together with a structured-extraction prompt.
+  5. Parse the JSON response from Bedrock.
+  6. Persist the extracted fields back to the leads table via UpdateItem.
+  7. Return the updated lead as JSON.
+
+Environment variables:
+  DYNAMO_TABLE_NAME   — leads table (default: leads)
+  DOCUMENTS_BUCKET    — S3 bucket where PDFs are stored
+  BEDROCK_MODEL_ID    — Bedrock model ID (default: us.anthropic.claude-3-5-haiku-20241022-v1:0)
+  AWS_DEFAULT_REGION  — AWS region (injected by Lambda runtime)
+"""
+
+import json
+import os
+import re
+from datetime import datetime, timezone
+from urllib.parse import urlparse
+
+import boto3
+from aws_lambda_powertools import Logger
+from aws_lambda_powertools.event_handler import APIGatewayRestResolver
+from aws_lambda_powertools.utilities.typing import LambdaContext
+
+from prompt import SYSTEM_PROMPT, USER_PROMPT
+
+logger = Logger(service="parse-document")
+api    = APIGatewayRestResolver()
+
+# ---------------------------------------------------------------------------
+# AWS clients (module-level so they are reused across warm invocations)
+# ---------------------------------------------------------------------------
+
+_region       = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
+_table_name   = os.environ.get("DYNAMO_TABLE_NAME", "leads")
+_bucket_name  = os.environ.get("DOCUMENTS_BUCKET", "")
+_model_id     = os.environ.get(
+    "BEDROCK_MODEL_ID",
+    "us.anthropic.claude-3-5-haiku-20241022-v1:0",
+)
+
+_dynamodb = boto3.resource("dynamodb", region_name=_region)
+_table    = _dynamodb.Table(_table_name)
+_s3       = boto3.client("s3", region_name=_region)
+_bedrock  = boto3.client("bedrock-runtime", region_name=_region)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _s3_uri_to_bucket_key(s3_uri: str) -> tuple[str, str]:
+    """Parse ``s3://bucket/key`` into ``(bucket, key)``."""
+    parsed = urlparse(s3_uri)
+    if parsed.scheme != "s3":
+        raise ValueError(f"Not an S3 URI: {s3_uri!r}")
+    bucket = parsed.netloc
+    key    = parsed.path.lstrip("/")
+    return bucket, key
+
+
+def _fetch_pdf_bytes(s3_uri: str) -> bytes:
+    """Download the PDF from S3 and return its raw bytes."""
+    bucket, key = _s3_uri_to_bucket_key(s3_uri)
+    response = _s3.get_object(Bucket=bucket, Key=key)
+    return response["Body"].read()
+
+
+def _call_bedrock(pdf_bytes: bytes) -> dict:
+    """
+    Send the PDF to Bedrock via the Converse API and return the parsed JSON dict.
+
+    The model is expected to return a single JSON object — no markdown fences.
+    If the response contains a fenced code block we strip the fences first.
+    """
+    response = _bedrock.converse(
+        modelId=_model_id,
+        system=[{"text": SYSTEM_PROMPT}],
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "document": {
+                            "format": "pdf",
+                            "name":   "probate-filing",
+                            "source": {"bytes": pdf_bytes},
+                        },
+                    },
+                    {"text": USER_PROMPT},
+                ],
+            }
+        ],
+        inferenceConfig={
+            "maxTokens": 1024,
+            "temperature": 0,
+        },
+    )
+
+    raw_text = response["output"]["message"]["content"][0]["text"].strip()
+
+    # Strip optional ```json ... ``` fences
+    fenced = re.match(r"^```(?:json)?\s*(.*?)\s*```$", raw_text, re.DOTALL)
+    if fenced:
+        raw_text = fenced.group(1).strip()
+
+    return json.loads(raw_text)
+
+
+def _persist_parsed_fields(lead_id: str, parsed: dict, model_id: str, error: str = "") -> None:
+    """
+    Write the extracted fields (and metadata) back to the leads table.
+    Uses UpdateItem so we only touch the parsed columns.
+    """
+    now = _now_iso()
+    _table.update_item(
+        Key={"doc_number": lead_id},
+        UpdateExpression=(
+            "SET parsed_at = :pa, parsed_model = :pm, parse_error = :pe,"
+            " deceased_name = :dn, deceased_dob = :db, deceased_dod = :dd,"
+            " deceased_last_address = :da, people = :pp,"
+            " real_property = :rp, summary = :su"
+        ),
+        ExpressionAttributeValues={
+            ":pa": now,
+            ":pm": model_id,
+            ":pe": error,
+            ":dn": parsed.get("deceased_name") or "",
+            ":db": parsed.get("deceased_dob")  or "",
+            ":dd": parsed.get("deceased_dod")  or "",
+            ":da": parsed.get("deceased_last_address") or "",
+            ":pp": parsed.get("people")        or [],
+            ":rp": parsed.get("real_property") or [],
+            ":su": parsed.get("summary")       or "",
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Route
+# ---------------------------------------------------------------------------
+
+@api.post("/real-estate/probate-leads/leads/<lead_id>/parse-document")
+def parse_document(lead_id: str):
+    # 1. Fetch the lead
+    result = _table.get_item(Key={"doc_number": lead_id})
+    item   = result.get("Item")
+    if not item:
+        return {"error": f"Lead not found: {lead_id!r}"}, 404
+
+    doc_s3_uri = item.get("doc_s3_uri", "")
+    if not doc_s3_uri:
+        return {
+            "error": (
+                f"Lead {lead_id!r} has no doc_s3_uri. "
+                "The document must be scraped and uploaded to S3 first."
+            )
+        }, 422
+
+    # 2. Fetch the PDF from S3
+    try:
+        pdf_bytes = _fetch_pdf_bytes(doc_s3_uri)
+    except Exception as exc:
+        logger.exception("S3 fetch failed", exc_info=exc)
+        err_msg = f"S3 fetch failed: {exc}"
+        _persist_parsed_fields(lead_id, {}, _model_id, error=err_msg)
+        return {"error": err_msg}, 500
+
+    # 3. Call Bedrock
+    try:
+        parsed = _call_bedrock(pdf_bytes)
+    except Exception as exc:
+        logger.exception("Bedrock call failed", exc_info=exc)
+        err_msg = f"Bedrock call failed: {exc}"
+        _persist_parsed_fields(lead_id, {}, _model_id, error=err_msg)
+        return {"error": err_msg}, 500
+
+    # 4. Persist parsed fields
+    try:
+        _persist_parsed_fields(lead_id, parsed, _model_id)
+    except Exception as exc:
+        logger.exception("DynamoDB update failed", exc_info=exc)
+        return {"error": f"DynamoDB update failed: {exc}"}, 500
+
+    # 5. Return the updated lead
+    updated = _table.get_item(Key={"doc_number": lead_id}).get("Item", item)
+
+    return {
+        "docNumber":           updated.get("doc_number", ""),
+        "docS3Uri":            updated.get("doc_s3_uri", ""),
+        "parsedAt":            updated.get("parsed_at", ""),
+        "parsedModel":         updated.get("parsed_model", ""),
+        "deceasedName":        updated.get("deceased_name", ""),
+        "deceasedDob":         updated.get("deceased_dob", ""),
+        "deceasedDod":         updated.get("deceased_dod", ""),
+        "deceasedLastAddress": updated.get("deceased_last_address", ""),
+        "people":              updated.get("people", []),
+        "realProperty":        updated.get("real_property", []),
+        "summary":             updated.get("summary", ""),
+        "parseError":          updated.get("parse_error", ""),
+    }, 200
+
+
+# ---------------------------------------------------------------------------
+# Handler
+# ---------------------------------------------------------------------------
+
+@logger.inject_lambda_context(log_event=False)
+def handler(event: dict, context: LambdaContext) -> dict:
+    return api.resolve(event, context)

--- a/src/parse_document/prompt.py
+++ b/src/parse_document/prompt.py
@@ -1,0 +1,42 @@
+"""
+Bedrock prompt for extracting structured data from a probate court PDF.
+
+The document is a legal filing that opens a probate case in a county court.
+It typically names the deceased, their dates of birth/death and last address,
+a list of heirs/beneficiaries/executors and their relationships to the deceased,
+and descriptions of real and personal property in the estate.
+"""
+
+SYSTEM_PROMPT = """\
+You are a legal document analyst specialising in probate court filings.
+Your task is to extract structured information from the document and return it
+as a single valid JSON object — no markdown, no prose, just JSON.
+
+Return ONLY this JSON shape (use null for any field you cannot find):
+
+{
+  "deceased_name":         "<full name of the deceased>",
+  "deceased_dob":          "<date of birth, YYYY-MM-DD if possible, else as written, or null>",
+  "deceased_dod":          "<date of death, YYYY-MM-DD if possible, else as written, or null>",
+  "deceased_last_address": "<last known street address of the deceased, or null>",
+  "people": [
+    {"name": "<full name>", "role": "<role or relationship, e.g. Executor, Heir, Attorney>"}
+  ],
+  "real_property": [
+    "<address or legal description of each piece of real property in the estate>"
+  ],
+  "summary": "<150-word or fewer plain-English summary of the filing>"
+}
+
+Rules:
+- Include every named person with their role/relationship.
+- For people with multiple roles list each role separately, or combine as \"Executor / Heir\".
+- If no real property is mentioned, return an empty array for real_property.
+- The summary must be 150 words or fewer and suitable for a non-lawyer audience.
+- Do not invent information that is not in the document.
+- Return only valid JSON — no trailing commas, no comments.
+"""
+
+USER_PROMPT = """\
+Please extract the structured information from the attached probate court document.
+"""

--- a/src/parse_document/requirements.txt
+++ b/src/parse_document/requirements.txt
@@ -1,0 +1,2 @@
+aws-lambda-powertools>=2.30.0
+boto3>=1.34.0

--- a/template.yaml
+++ b/template.yaml
@@ -61,6 +61,13 @@ Parameters:
       S3 bucket name for storing scraped documents. Leave blank to let
       CloudFormation generate a unique name.
 
+  BedrockModelId:
+    Type: String
+    Default: "us.anthropic.claude-3-5-haiku-20241022-v1:0"
+    Description: >
+      Amazon Bedrock model ID used by ParseDocumentFunction.
+      Must be available in the deployment region.
+
 # ---------------------------------------------------------------------------
 # Conditions
 # ---------------------------------------------------------------------------
@@ -480,6 +487,51 @@ Resources:
           Properties:
             RestApiId: !Ref ProbateApi
             Path: /real-estate/probate-leads/{location_path}/update
+            Method: POST
+
+  # ── Lambda — POST /leads/{lead_id}/parse-document ─────────────────────────
+  # Separate function with a longer timeout (Bedrock can take 10-30 s per PDF).
+  # Needs: s3:GetObject on DocumentsBucket, bedrock:InvokeModel,
+  #        dynamodb:GetItem + dynamodb:UpdateItem on LeadsTable.
+
+  ParseDocumentFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: probate-leads-parse-document
+      CodeUri: src/parse_document/
+      Handler: app.handler
+      MemorySize: 512
+      Timeout: 120
+      Environment:
+        Variables:
+          DOCUMENTS_BUCKET: !Ref DocumentsBucket
+          BEDROCK_MODEL_ID: !Ref BedrockModelId
+      Policies:
+        # Leads — read + update parsed fields
+        - Statement:
+            - Effect: Allow
+              Action:
+                - dynamodb:GetItem
+                - dynamodb:UpdateItem
+              Resource: !GetAtt LeadsTable.Arn
+        # S3 — read PDFs from the documents bucket
+        - Statement:
+            - Effect: Allow
+              Action:
+                - s3:GetObject
+              Resource: !Sub "${DocumentsBucket.Arn}/documents/*"
+        # Bedrock — invoke the extraction model
+        - Statement:
+            - Effect: Allow
+              Action:
+                - bedrock:InvokeModel
+              Resource: !Sub "arn:aws:bedrock:${AWS::Region}::foundation-model/${BedrockModelId}"
+      Events:
+        ParseDocument:
+          Type: Api
+          Properties:
+            RestApiId: !Ref ProbateApi
+            Path: /real-estate/probate-leads/leads/{lead_id}/parse-document
             Method: POST
 
   # ── EventBridge — daily scheduled scrape ─────────────────────────────────

--- a/tests/events/post-parse-document.json
+++ b/tests/events/post-parse-document.json
@@ -1,0 +1,14 @@
+{
+  "resource": "/real-estate/probate-leads/leads/{lead_id}/parse-document",
+  "path": "/real-estate/probate-leads/leads/20260000023696/parse-document",
+  "httpMethod": "POST",
+  "headers": {
+    "x-api-key": "test-api-key"
+  },
+  "pathParameters": {
+    "lead_id": "20260000023696"
+  },
+  "queryStringParameters": null,
+  "body": null,
+  "isBase64Encoded": false
+}

--- a/tests/test_parse_document.py
+++ b/tests/test_parse_document.py
@@ -1,0 +1,418 @@
+"""
+Unit tests for src/parse_document/app.py
+
+Covers:
+  - Happy path: S3 + Bedrock succeed → fields persisted, 200 returned
+  - Lead not found → 404
+  - Lead has no doc_s3_uri → 422
+  - S3 fetch fails → parse_error stored, 500 returned
+  - Bedrock call fails → parse_error stored, 500 returned
+  - DynamoDB update fails → 500 returned
+  - Markdown-fenced JSON response is handled correctly
+  - _s3_uri_to_bucket_key parses correctly
+"""
+
+import json
+import sys
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+# ---------------------------------------------------------------------------
+# Path setup — add src/parse_document so 'prompt' can be found at import time
+# ---------------------------------------------------------------------------
+import importlib.util
+import types
+
+_PARSE_DOC_SRC = os.path.join(os.path.dirname(__file__), "..", "src", "parse_document")
+sys.path.insert(0, _PARSE_DOC_SRC)
+
+# Stub out aws_lambda_powertools before importing app so we don't need the
+# full package installed.  We only need Logger + APIGatewayRestResolver.
+
+# Minimal Logger stub
+_powertools_pkg = types.ModuleType("aws_lambda_powertools")
+_Logger_stub = MagicMock()
+_Logger_instance = MagicMock()
+_Logger_instance.inject_lambda_context = lambda **kw: (lambda f: f)
+_Logger_instance.exception = lambda *a, **kw: None
+_Logger_stub.return_value = _Logger_instance
+_powertools_pkg.Logger = _Logger_stub
+
+# Minimal APIGatewayRestResolver stub — post() must return the function unchanged
+_resolver_instance = MagicMock()
+_resolver_instance.post = lambda path: (lambda f: f)
+_resolver_instance.resolve = MagicMock(return_value={"statusCode": 200})
+_resolver_cls = MagicMock(return_value=_resolver_instance)
+
+_event_handler_mod = types.ModuleType("aws_lambda_powertools.event_handler")
+_event_handler_mod.APIGatewayRestResolver = _resolver_cls
+
+_utilities_mod  = types.ModuleType("aws_lambda_powertools.utilities")
+_typing_mod     = types.ModuleType("aws_lambda_powertools.utilities.typing")
+_typing_mod.LambdaContext = object
+
+sys.modules.setdefault("aws_lambda_powertools", _powertools_pkg)
+sys.modules.setdefault("aws_lambda_powertools.event_handler", _event_handler_mod)
+sys.modules.setdefault("aws_lambda_powertools.utilities", _utilities_mod)
+sys.modules.setdefault("aws_lambda_powertools.utilities.typing", _typing_mod)
+
+# Load src/parse_document/app.py by file path with a unique module name so it
+# does NOT collide with the "app" module that test_api.py already cached in
+# sys.modules (Python caches by name, not by path).
+def _load_parse_document_app():
+    spec = importlib.util.spec_from_file_location(
+        "parse_document_app",
+        os.path.join(_PARSE_DOC_SRC, "app.py"),
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["parse_document_app"] = mod
+    with patch("boto3.resource"), patch("boto3.client"):
+        spec.loader.exec_module(mod)
+    return mod
+
+parse_app = _load_parse_document_app()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_GOOD_BEDROCK_PAYLOAD = {
+    "deceased_name":         "Jane A. Smith",
+    "deceased_dob":          "1942-03-15",
+    "deceased_dod":          "2025-11-01",
+    "deceased_last_address": "123 Main St, Plano, TX 75001",
+    "people": [
+        {"name": "Robert Smith",   "role": "Executor"},
+        {"name": "Emily Jones",    "role": "Heir"},
+        {"name": "Tom Brown, Esq", "role": "Attorney"},
+    ],
+    "real_property": [
+        "123 Main St, Plano, TX 75001",
+        "Lot 7, Block 3, Willow Creek Estates",
+    ],
+    "summary": (
+        "This probate petition was filed on behalf of the estate of Jane A. Smith, "
+        "who died on 1 November 2025 in Collin County, Texas. Her son Robert Smith "
+        "is named independent executor. Two heirs and one attorney are listed. The "
+        "estate includes the decedent's primary residence and one additional parcel."
+    ),
+}
+
+
+def _make_lead(doc_s3_uri: str = "s3://mybucket/documents/CollinTx/20240001.pdf") -> dict:
+    return {
+        "doc_number": "20240001",
+        "grantor":    "Smith, Jane A.",
+        "doc_s3_uri": doc_s3_uri,
+    }
+
+
+def _bedrock_response(payload: dict | str) -> dict:
+    """Build a minimal Bedrock Converse response dict."""
+    text = payload if isinstance(payload, str) else json.dumps(payload)
+    return {
+        "output": {
+            "message": {
+                "content": [{"text": text}]
+            }
+        }
+    }
+
+
+# ---------------------------------------------------------------------------
+# _s3_uri_to_bucket_key
+# ---------------------------------------------------------------------------
+
+class TestS3UriParsing(unittest.TestCase):
+
+    def test_standard_uri(self):
+        bucket, key = parse_app._s3_uri_to_bucket_key(
+            "s3://mybucket/documents/CollinTx/20240001.pdf"
+        )
+        self.assertEqual(bucket, "mybucket")
+        self.assertEqual(key,    "documents/CollinTx/20240001.pdf")
+
+    def test_uri_without_leading_slash_in_key(self):
+        bucket, key = parse_app._s3_uri_to_bucket_key("s3://b/k/e/y")
+        self.assertEqual(bucket, "b")
+        self.assertEqual(key,    "k/e/y")
+
+    def test_invalid_scheme_raises(self):
+        with self.assertRaises(ValueError):
+            parse_app._s3_uri_to_bucket_key("https://example.com/file.pdf")
+
+
+# ---------------------------------------------------------------------------
+# parse_document route
+# ---------------------------------------------------------------------------
+
+class TestParseDocument(unittest.TestCase):
+
+    def setUp(self):
+        """Replace the module-level AWS clients with fresh MagicMocks."""
+        self.mock_table   = MagicMock()
+        self.mock_s3      = MagicMock()
+        self.mock_bedrock = MagicMock()
+
+        parse_app._table   = self.mock_table
+        parse_app._s3      = self.mock_s3
+        parse_app._bedrock = self.mock_bedrock
+        parse_app._model_id = "us.anthropic.claude-3-5-haiku-20241022-v1:0"
+
+    # ── 404 — lead not found ────────────────────────────────────────────────
+
+    def test_lead_not_found_returns_404(self):
+        self.mock_table.get_item.return_value = {"Item": None}
+        body, status = parse_app.parse_document("99999999")
+        self.assertEqual(status, 404)
+        self.assertIn("not found", body["error"].lower())
+
+    def test_lead_missing_from_response_returns_404(self):
+        self.mock_table.get_item.return_value = {}
+        body, status = parse_app.parse_document("99999999")
+        self.assertEqual(status, 404)
+
+    # ── 422 — no doc_s3_uri ─────────────────────────────────────────────────
+
+    def test_no_doc_s3_uri_returns_422(self):
+        lead = _make_lead(doc_s3_uri="")
+        self.mock_table.get_item.return_value = {"Item": lead}
+        body, status = parse_app.parse_document("20240001")
+        self.assertEqual(status, 422)
+        self.assertIn("doc_s3_uri", body["error"])
+
+    # ── 500 — S3 fetch fails ────────────────────────────────────────────────
+
+    def test_s3_failure_returns_500_and_stores_parse_error(self):
+        self.mock_table.get_item.return_value = {"Item": _make_lead()}
+        self.mock_s3.get_object.side_effect = Exception("NoSuchKey")
+
+        body, status = parse_app.parse_document("20240001")
+
+        self.assertEqual(status, 500)
+        self.assertIn("S3 fetch failed", body["error"])
+
+        # parse_error must be persisted via update_item
+        self.mock_table.update_item.assert_called_once()
+        call_kwargs = self.mock_table.update_item.call_args.kwargs
+        self.assertIn("NoSuchKey", call_kwargs["ExpressionAttributeValues"][":pe"])
+
+    # ── 500 — Bedrock fails ─────────────────────────────────────────────────
+
+    def test_bedrock_failure_returns_500_and_stores_parse_error(self):
+        self.mock_table.get_item.return_value = {"Item": _make_lead()}
+        self.mock_s3.get_object.return_value  = {
+            "Body": MagicMock(read=MagicMock(return_value=b"%PDF fake"))
+        }
+        self.mock_bedrock.converse.side_effect = Exception("ThrottlingException")
+
+        body, status = parse_app.parse_document("20240001")
+
+        self.assertEqual(status, 500)
+        self.assertIn("Bedrock call failed", body["error"])
+        self.mock_table.update_item.assert_called_once()
+        call_kwargs = self.mock_table.update_item.call_args.kwargs
+        self.assertIn("ThrottlingException", call_kwargs["ExpressionAttributeValues"][":pe"])
+
+    # ── 500 — DynamoDB update fails ─────────────────────────────────────────
+
+    def test_dynamodb_update_failure_returns_500(self):
+        self.mock_table.get_item.return_value = {"Item": _make_lead()}
+        self.mock_s3.get_object.return_value  = {
+            "Body": MagicMock(read=MagicMock(return_value=b"%PDF fake"))
+        }
+        self.mock_bedrock.converse.return_value = _bedrock_response(_GOOD_BEDROCK_PAYLOAD)
+        self.mock_table.update_item.side_effect = Exception("ProvisionedThroughputExceeded")
+
+        body, status = parse_app.parse_document("20240001")
+
+        self.assertEqual(status, 500)
+        self.assertIn("DynamoDB update failed", body["error"])
+
+    # ── 200 — happy path ────────────────────────────────────────────────────
+
+    def test_happy_path_returns_200_with_parsed_fields(self):
+        lead = _make_lead()
+        self.mock_table.get_item.side_effect = [
+            {"Item": lead},                           # first call (fetch lead)
+            {"Item": {**lead, **_GOOD_BEDROCK_PAYLOAD,  # second call (re-fetch after update)
+                      "parsed_at": "2026-02-26T00:00:00+00:00",
+                      "parsed_model": parse_app._model_id,
+                      "parse_error": ""}},
+        ]
+        self.mock_s3.get_object.return_value = {
+            "Body": MagicMock(read=MagicMock(return_value=b"%PDF fake"))
+        }
+        self.mock_bedrock.converse.return_value = _bedrock_response(_GOOD_BEDROCK_PAYLOAD)
+
+        body, status = parse_app.parse_document("20240001")
+
+        self.assertEqual(status, 200)
+        self.assertEqual(body["deceasedName"], "Jane A. Smith")
+        self.assertEqual(body["deceasedDob"],  "1942-03-15")
+        self.assertEqual(body["deceasedDod"],  "2025-11-01")
+        self.assertEqual(body["deceasedLastAddress"], "123 Main St, Plano, TX 75001")
+        self.assertEqual(len(body["people"]),       3)
+        self.assertEqual(len(body["realProperty"]), 2)
+        self.assertIn("Jane A. Smith", body["summary"])
+        self.assertEqual(body["parseError"], "")
+
+    def test_happy_path_persists_correct_update_expression(self):
+        lead = _make_lead()
+        self.mock_table.get_item.side_effect = [
+            {"Item": lead},
+            {"Item": {**lead, **_GOOD_BEDROCK_PAYLOAD,
+                      "parsed_at": "2026-02-26T00:00:00+00:00",
+                      "parsed_model": parse_app._model_id,
+                      "parse_error": ""}},
+        ]
+        self.mock_s3.get_object.return_value = {
+            "Body": MagicMock(read=MagicMock(return_value=b"%PDF fake"))
+        }
+        self.mock_bedrock.converse.return_value = _bedrock_response(_GOOD_BEDROCK_PAYLOAD)
+
+        parse_app.parse_document("20240001")
+
+        self.mock_table.update_item.assert_called_once()
+        call_kwargs = self.mock_table.update_item.call_args.kwargs
+        ev = call_kwargs["ExpressionAttributeValues"]
+        self.assertEqual(ev[":dn"], "Jane A. Smith")
+        self.assertEqual(ev[":pe"], "")   # no error on happy path
+        self.assertEqual(len(ev[":pp"]), 3)
+        self.assertEqual(len(ev[":rp"]), 2)
+
+    # ── Markdown-fenced response ─────────────────────────────────────────────
+
+    def test_fenced_json_response_is_parsed_correctly(self):
+        fenced = f"```json\n{json.dumps(_GOOD_BEDROCK_PAYLOAD)}\n```"
+        lead   = _make_lead()
+        self.mock_table.get_item.side_effect = [
+            {"Item": lead},
+            {"Item": {**lead, **_GOOD_BEDROCK_PAYLOAD,
+                      "parsed_at": "2026-02-26T00:00:00+00:00",
+                      "parsed_model": parse_app._model_id,
+                      "parse_error": ""}},
+        ]
+        self.mock_s3.get_object.return_value = {
+            "Body": MagicMock(read=MagicMock(return_value=b"%PDF fake"))
+        }
+        self.mock_bedrock.converse.return_value = _bedrock_response(fenced)
+
+        body, status = parse_app.parse_document("20240001")
+        self.assertEqual(status, 200)
+        self.assertEqual(body["deceasedName"], "Jane A. Smith")
+
+    def test_plain_fenced_block_no_language_tag(self):
+        fenced = f"```\n{json.dumps(_GOOD_BEDROCK_PAYLOAD)}\n```"
+        lead   = _make_lead()
+        self.mock_table.get_item.side_effect = [
+            {"Item": lead},
+            {"Item": {**lead, **_GOOD_BEDROCK_PAYLOAD,
+                      "parsed_at": "2026-02-26T00:00:00+00:00",
+                      "parsed_model": parse_app._model_id,
+                      "parse_error": ""}},
+        ]
+        self.mock_s3.get_object.return_value = {
+            "Body": MagicMock(read=MagicMock(return_value=b"%PDF fake"))
+        }
+        self.mock_bedrock.converse.return_value = _bedrock_response(fenced)
+
+        body, status = parse_app.parse_document("20240001")
+        self.assertEqual(status, 200)
+        self.assertEqual(body["deceasedName"], "Jane A. Smith")
+
+    # ── S3 URI is forwarded correctly to boto3 ──────────────────────────────
+
+    def test_s3_get_object_called_with_correct_bucket_and_key(self):
+        lead = _make_lead("s3://mybucket/documents/CollinTx/20240001.pdf")
+        self.mock_table.get_item.side_effect = [
+            {"Item": lead},
+            {"Item": {**lead, **_GOOD_BEDROCK_PAYLOAD,
+                      "parsed_at": "2026-02-26T00:00:00+00:00",
+                      "parsed_model": parse_app._model_id,
+                      "parse_error": ""}},
+        ]
+        self.mock_s3.get_object.return_value = {
+            "Body": MagicMock(read=MagicMock(return_value=b"%PDF fake"))
+        }
+        self.mock_bedrock.converse.return_value = _bedrock_response(_GOOD_BEDROCK_PAYLOAD)
+
+        parse_app.parse_document("20240001")
+
+        self.mock_s3.get_object.assert_called_once_with(
+            Bucket="mybucket",
+            Key="documents/CollinTx/20240001.pdf",
+        )
+
+    # ── Bedrock PDF bytes forwarded ──────────────────────────────────────────
+
+    def test_pdf_bytes_forwarded_to_bedrock(self):
+        pdf_content = b"%PDF-1.4 fake content"
+        lead = _make_lead()
+        self.mock_table.get_item.side_effect = [
+            {"Item": lead},
+            {"Item": {**lead, **_GOOD_BEDROCK_PAYLOAD,
+                      "parsed_at": "2026-02-26T00:00:00+00:00",
+                      "parsed_model": parse_app._model_id,
+                      "parse_error": ""}},
+        ]
+        self.mock_s3.get_object.return_value = {
+            "Body": MagicMock(read=MagicMock(return_value=pdf_content))
+        }
+        self.mock_bedrock.converse.return_value = _bedrock_response(_GOOD_BEDROCK_PAYLOAD)
+
+        parse_app.parse_document("20240001")
+
+        converse_call = self.mock_bedrock.converse.call_args.kwargs
+        doc_block = converse_call["messages"][0]["content"][0]["document"]
+        self.assertEqual(doc_block["source"]["bytes"], pdf_content)
+        self.assertEqual(doc_block["format"], "pdf")
+
+    # ── Null fields from Bedrock are handled gracefully ──────────────────────
+
+    def test_null_optional_fields_handled(self):
+        # Bedrock returns None for optional fields
+        sparse_bedrock = {
+            "deceased_name":         "Unknown Decedent",
+            "deceased_dob":          None,
+            "deceased_dod":          None,
+            "deceased_last_address": None,
+            "people":                [],
+            "real_property":         [],
+            "summary":               "A probate filing with minimal information.",
+        }
+        # _persist_parsed_fields coerces None → ""; the re-fetched DynamoDB item
+        # reflects the persisted (coerced) values, not the raw Bedrock payload.
+        stored = {
+            "deceased_name":         "Unknown Decedent",
+            "deceased_dob":          "",
+            "deceased_dod":          "",
+            "deceased_last_address": "",
+            "people":                [],
+            "real_property":         [],
+            "summary":               "A probate filing with minimal information.",
+        }
+        lead = _make_lead()
+        self.mock_table.get_item.side_effect = [
+            {"Item": lead},
+            {"Item": {**lead, **stored,
+                      "parsed_at":    "2026-02-26T00:00:00+00:00",
+                      "parsed_model": parse_app._model_id,
+                      "parse_error":  ""}},
+        ]
+        self.mock_s3.get_object.return_value = {
+            "Body": MagicMock(read=MagicMock(return_value=b"%PDF fake"))
+        }
+        self.mock_bedrock.converse.return_value = _bedrock_response(sparse_bedrock)
+
+        body, status = parse_app.parse_document("20240001")
+        self.assertEqual(status, 200)
+        self.assertEqual(body["deceasedDob"], "")   # None coerced → "" by persist helper
+        self.assertEqual(body["people"],      [])
+        self.assertEqual(body["realProperty"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #25

## Summary

- New **`ParseDocumentFunction`** Lambda (`src/parse_document/`) — 120s timeout, 512MB memory, separate from the 10s `ApiFunction`
- Fetches the probate court PDF from S3, sends it to **Amazon Bedrock** (Claude 3.5 Haiku) via the Converse API, and extracts structured fields
- Persists results back to DynamoDB via `UpdateItem` (only the parsed columns are touched)
- **`Lead` model** extended with `doc_s3_uri` + 10 `parsed_*` fields; all serialized to camelCase in `to_dict()`
- **`template.yaml`** gains a `BedrockModelId` parameter and the `ParseDocumentFunction` resource with least-privilege IAM (`s3:GetObject`, `bedrock:InvokeModel`, `dynamodb:GetItem/UpdateItem`)

## Extracted fields

| Field | Description |
|---|---|
| `deceasedName` | Full name of the deceased |
| `deceasedDob` | Date of birth |
| `deceasedDod` | Date of death |
| `deceasedLastAddress` | Last known address |
| `people` | `[{name, role}]` — executor, heirs, attorneys, etc. |
| `realProperty` | Property addresses / legal descriptions in the estate |
| `summary` | ≤150-word plain-English summary |
| `parseError` | Set on failure; empty on success |
| `parsedAt` | ISO-8601 UTC timestamp |
| `parsedModel` | Bedrock model ID used |

## Test plan

- [ ] 209 unit tests pass (`make test`)
- [ ] Happy path: mocked S3 + Bedrock → correct fields persisted, 200 returned
- [ ] Lead not found → 404
- [ ] No `doc_s3_uri` → 422
- [ ] S3 fetch fails → `parse_error` stored, 500 returned
- [ ] Bedrock fails → `parse_error` stored, 500 returned
- [ ] DynamoDB update fails → 500 returned
- [ ] Markdown-fenced JSON from Bedrock is stripped and parsed correctly
- [ ] Null optional fields coerced to `""` / `[]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)