### PR TITLE
fix: convert PDF pages to JPEG images for Bedrock cross-region inference

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ webdriver-manager = ">=4.0.0"
 openpyxl = ">=3.1.0"
 boto3 = "*"
 aws-lambda-powertools = "*"
+pymupdf = "*"
 
 [dev-packages]
 ipykernel = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "5f9ca415708a88f4763104249b942d9f5ede50d5f283124e86856a359052027a"
+            "sha256": "b8e62d4412d086bb6dd2653169f11b7a902e3eabc263a0395598c43e550356b2"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -375,6 +375,21 @@
             "index": "pypi",
             "markers": "python_version >= '3.11'",
             "version": "==3.0.0"
+        },
+        "pymupdf": {
+            "hashes": [
+                "sha256:2c9d9353b840040cbc724341f4095fb7e2cc1a12a9147d0ec1a0a79f5d773147",
+                "sha256:3de95a0889395b0966fafd11b94980b7543a816e89dd1c218597a08543ac3415",
+                "sha256:4afbde0769c336717a149ab0de3330dcb75378f795c1a8c5af55c1a628b17d55",
+                "sha256:4b6268dff3a9d713034eba5c2ffce0da37c62443578941ac5df433adcde57b2f",
+                "sha256:4f1837554134fb45d390a44de8844b2ca9b6c901c82ccc90b340e3b7f3b126ca",
+                "sha256:aeaed76e72cbc061149a825ab0811c5f4752970c56591c2938c5042ec06b26e1",
+                "sha256:bee9f95512f9556dbf2cacfd1413c61b29a55baa07fa7f8fc83d221d8419888a",
+                "sha256:fa33b512d82c6c4852edadf57f22d5f27d16243bb33dac0fbe4eb0f281c5b17e"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.10'",
+            "version": "==1.27.1"
         },
         "pysocks": {
             "hashes": [

--- a/src/parse_document/app.py
+++ b/src/parse_document/app.py
@@ -28,6 +28,7 @@ from datetime import datetime, timezone
 from urllib.parse import urlparse
 
 import boto3
+import fitz  # PyMuPDF
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver
 from aws_lambda_powertools.utilities.typing import LambdaContext
@@ -80,31 +81,52 @@ def _fetch_pdf_bytes(s3_uri: str) -> bytes:
     return response["Body"].read()
 
 
+_MAX_PDF_PAGES = 20
+
+
+def _pdf_to_page_images(pdf_bytes: bytes) -> list[bytes]:
+    """
+    Render each page of a PDF to a JPEG image.
+
+    AWS Bedrock document blocks are NOT supported with cross-region inference
+    profiles (``us.*`` model IDs).  Sending the pages as image blocks is the
+    workaround — image blocks work fine with cross-region inference.
+    """
+    doc = fitz.open(stream=pdf_bytes, filetype="pdf")
+    images = []
+    for page_num in range(min(doc.page_count, _MAX_PDF_PAGES)):
+        page = doc.load_page(page_num)
+        pix  = page.get_pixmap(matrix=fitz.Matrix(1.5, 1.5))
+        images.append(pix.tobytes("jpeg"))
+    doc.close()
+    return images
+
+
 def _call_bedrock(pdf_bytes: bytes) -> dict:
     """
-    Send the PDF to Bedrock via the Converse API and return the parsed JSON dict.
+    Send PDF pages as JPEG images to Bedrock and return the parsed JSON dict.
+
+    Image blocks are used instead of a document block because AWS Bedrock
+    document blocks are not supported with cross-region inference profiles
+    (``us.*`` model IDs).  Image blocks work with cross-region inference.
 
     The model is expected to return a single JSON object — no markdown fences.
     If the response contains a fenced code block we strip the fences first.
     """
+    page_images = _pdf_to_page_images(pdf_bytes)
+    if not page_images:
+        raise ValueError("PDF produced no pages")
+
+    content = [
+        {"image": {"format": "jpeg", "source": {"bytes": img}}}
+        for img in page_images
+    ]
+    content.append({"text": USER_PROMPT})
+
     response = _bedrock.converse(
         modelId=_model_id,
         system=[{"text": SYSTEM_PROMPT}],
-        messages=[
-            {
-                "role": "user",
-                "content": [
-                    {
-                        "document": {
-                            "format": "pdf",
-                            "name":   "probate-filing",
-                            "source": {"bytes": pdf_bytes},
-                        },
-                    },
-                    {"text": USER_PROMPT},
-                ],
-            }
-        ],
+        messages=[{"role": "user", "content": content}],
         inferenceConfig={
             "maxTokens": 1024,
             "temperature": 0,

--- a/src/parse_document/requirements.txt
+++ b/src/parse_document/requirements.txt
@@ -1,2 +1,3 @@
 aws-lambda-powertools>=2.30.0
 boto3>=1.34.0
+PyMuPDF>=1.24.0

--- a/tests/test_parse_document.py
+++ b/tests/test_parse_document.py
@@ -161,6 +161,17 @@ class TestParseDocument(unittest.TestCase):
         parse_app._bedrock = self.mock_bedrock
         parse_app._model_id = "us.anthropic.claude-3-5-haiku-20241022-v1:0"
 
+        # Stub _pdf_to_page_images so tests don't need a real PDF / PyMuPDF.
+        self._page_images_patcher = patch.object(
+            parse_app,
+            "_pdf_to_page_images",
+            return_value=[b"fake-jpeg-page-1"],
+        )
+        self._page_images_patcher.start()
+
+    def tearDown(self):
+        self._page_images_patcher.stop()
+
     # ── 404 — lead not found ────────────────────────────────────────────────
 
     def test_lead_not_found_returns_404(self):
@@ -346,9 +357,15 @@ class TestParseDocument(unittest.TestCase):
             Key="documents/CollinTx/20240001.pdf",
         )
 
-    # ── Bedrock PDF bytes forwarded ──────────────────────────────────────────
+    # ── Bedrock receives image blocks (not a document block) ────────────────
 
-    def test_pdf_bytes_forwarded_to_bedrock(self):
+    def test_page_images_forwarded_to_bedrock_as_image_blocks(self):
+        """_pdf_to_page_images output must be sent as image blocks.
+
+        AWS Bedrock document blocks are not supported with cross-region
+        inference profiles.  The fix converts the PDF to per-page JPEG images
+        and sends them as image content blocks instead.
+        """
         pdf_content = b"%PDF-1.4 fake content"
         lead = _make_lead()
         self.mock_table.get_item.side_effect = [
@@ -366,9 +383,20 @@ class TestParseDocument(unittest.TestCase):
         parse_app.parse_document("20240001")
 
         converse_call = self.mock_bedrock.converse.call_args.kwargs
-        doc_block = converse_call["messages"][0]["content"][0]["document"]
-        self.assertEqual(doc_block["source"]["bytes"], pdf_content)
-        self.assertEqual(doc_block["format"], "pdf")
+        content_blocks = converse_call["messages"][0]["content"]
+
+        # First block must be an image block (not a document block)
+        first_block = content_blocks[0]
+        self.assertIn("image", first_block, "Expected image block, got: " + str(first_block))
+        self.assertEqual(first_block["image"]["format"], "jpeg")
+        self.assertEqual(first_block["image"]["source"]["bytes"], b"fake-jpeg-page-1")
+
+        # Last block must be the text prompt
+        self.assertIn("text", content_blocks[-1])
+
+        # No document blocks anywhere
+        for block in content_blocks:
+            self.assertNotIn("document", block, "document block found — use image blocks instead")
 
     # ── Null fields from Bedrock are handled gracefully ──────────────────────
 


### PR DESCRIPTION
## Problem

After deploying the `parse-document` endpoint, calling it returned a 200 response but all extracted fields were empty:

```json
{"deceasedName":"","people":[],"realProperty":[],"summary":"","parseError":""}
```

Root cause: **AWS Bedrock document blocks are not supported with cross-region inference profiles** (`us.*` model IDs). The `converse()` call succeeds without error but silently ignores the document content, so the model sees no input and returns null/empty values for every field. Lambda completed in ~1968 ms — far too fast for a 14-page PDF.

Reference: AWS docs confirm "Document understanding is not supported for cross-region inference."

## Fix

Replace the `document` block with per-page **image blocks**. Image blocks _are_ supported with cross-region inference.

- Add `PyMuPDF>=1.24.0` as a Lambda dependency
- `_pdf_to_page_images(pdf_bytes)` renders each page to a 1.5× JPEG via `fitz`
- `_call_bedrock()` builds one `{"image": ...}` block per page, then appends the text prompt

## Test plan

- [x] 209 unit tests pass (`make test`)
- [x] `test_page_images_forwarded_to_bedrock_as_image_blocks` verifies image blocks are sent and no `document` block is present
- [ ] Deploy and call `POST /real-estate/probate-leads/leads/2026000023696/parse-document` — expect `deceasedName: "Robert Doro Jackson"` and populated fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)