### PR TITLE
feat: parse-document endpoint (Bedrock PDF extraction)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ STACK_NAME   := probate-scraper-collin-tx
 .PHONY: help ecr-create ecr-login build push build-push sam-build deploy \
         run-task logs-scraper logs-api get-api-key invoke-trigger invoke-api \
         vpc-info local-db-start local-db-stop local-db-seed local-db-reset local-db-shell \
-        aws-db-reset local-api-start local-scraper-run test smoke-test
+        aws-db-reset local-api-start local-scraper-run test smoke-test check-bedrock
 
 LOCAL_DYNAMO_URL := http://localhost:8000
 LOCAL_ENV        := AWS_ENDPOINT_URL=$(LOCAL_DYNAMO_URL) AWS_DEFAULT_REGION=us-east-1 \
@@ -40,6 +40,7 @@ help:
 	@echo "                       SCRAPER_USERNAME=x SCRAPER_PASSWORD='y' make local-scraper-run"
 	@echo "    test             Run unit tests"
 	@echo "    smoke-test       Smoke test the deployed API (set SMOKE_BASE_URL + SMOKE_API_KEY)"
+	@echo "    check-bedrock    Verify Bedrock model access before deploying ParseDocumentFunction"
 	@echo ""
 	@echo "  Setup (one-time):"
 	@echo "    ecr-create       Create the ECR repository"
@@ -181,6 +182,11 @@ test:
 #   make smoke-test
 smoke-test:
 	pipenv run python scripts/smoke_test.py
+
+# Verify the Bedrock model is accessible before deploying ParseDocumentFunction.
+# Run once per account/region after initial AWS setup, or after changing BedrockModelId.
+check-bedrock:
+	pipenv run python scripts/check_bedrock.py
 
 # ── Local DynamoDB ───────────────────────────────────────────────────────────
 

--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ webdriver-manager = ">=4.0.0"
 openpyxl = ">=3.1.0"
 boto3 = "*"
 aws-lambda-powertools = "*"
+PyMuPDF = "*"
 
 [dev-packages]
 ipykernel = "*"

--- a/scripts/check_bedrock.py
+++ b/scripts/check_bedrock.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""
+Verify that the configured Bedrock model is accessible in this account/region.
+
+Run this before deploying ParseDocumentFunction to confirm that the model
+can be invoked.  Exits 0 on success, 1 on any failure.
+
+Usage:
+    pipenv run python scripts/check_bedrock.py
+
+    # Override model or region:
+    BEDROCK_MODEL_ID=us.anthropic.claude-3-5-haiku-20241022-v1:0 \\
+    AWS_DEFAULT_REGION=us-east-1 \\
+    pipenv run python scripts/check_bedrock.py
+
+Environment variables:
+    BEDROCK_MODEL_ID   Model to test (default: us.anthropic.claude-3-5-haiku-20241022-v1:0)
+    AWS_DEFAULT_REGION AWS region    (default: us-east-1)
+"""
+
+import os
+import sys
+
+import boto3
+from botocore.exceptions import ClientError, NoCredentialsError
+
+MODEL_ID = os.environ.get(
+    "BEDROCK_MODEL_ID",
+    "us.anthropic.claude-3-5-haiku-20241022-v1:0",
+)
+REGION = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
+
+GREEN  = "\033[32m"
+RED    = "\033[31m"
+YELLOW = "\033[33m"
+RESET  = "\033[0m"
+
+
+def main() -> int:
+    print(f"\n{'='*70}")
+    print(f"  Bedrock access check")
+    print(f"  Model:  {MODEL_ID}")
+    print(f"  Region: {REGION}")
+    print(f"{'='*70}\n")
+
+    try:
+        client = boto3.client("bedrock-runtime", region_name=REGION)
+        response = client.converse(
+            modelId=MODEL_ID,
+            messages=[{
+                "role":    "user",
+                "content": [{"text": "Reply with the single word: ok"}],
+            }],
+            inferenceConfig={"maxTokens": 10, "temperature": 0},
+        )
+        reply = response["output"]["message"]["content"][0]["text"].strip()
+        print(f"  {GREEN}✓{RESET}  Model responded: {reply!r}")
+        print(f"\n  {GREEN}PASSED{RESET} — Bedrock access confirmed, safe to deploy.\n")
+        return 0
+
+    except NoCredentialsError:
+        print(f"  {RED}✗{RESET}  No AWS credentials found.\n")
+        print("  Configure credentials via ~/.aws/credentials, AWS_PROFILE,")
+        print("  or AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY env vars.\n")
+        return 1
+
+    except ClientError as exc:
+        code = exc.response["Error"]["Code"]
+        msg  = exc.response["Error"]["Message"]
+        print(f"  {RED}✗{RESET}  {code}: {msg}\n")
+
+        if "use case details" in msg.lower():
+            print(f"  {YELLOW}ACTION REQUIRED{RESET}: Submit Anthropic use case details.\n")
+            print("  AWS requires a one-time use case form for Anthropic models.")
+            print("  Steps:")
+            print(f"    1. Open the Bedrock model catalog:")
+            print(f"       https://{REGION}.console.aws.amazon.com/bedrock/home?region={REGION}#/model-catalog")
+            print(f"    2. Search for 'Claude 3.5 Haiku'")
+            print(f"    3. Click the model → complete the use case details form")
+            print(f"    4. Wait for approval (usually instant) then re-run: make check-bedrock\n")
+
+        elif code == "AccessDeniedException":
+            print(f"  {YELLOW}Fix{RESET}: IAM role/user is missing bedrock:InvokeModel permission.")
+            print(f"  Add this to the relevant IAM policy:")
+            print(f'    {{"Effect": "Allow", "Action": "bedrock:InvokeModel", "Resource": "*"}}\n')
+
+        elif code == "ValidationException" and "on-demand throughput" in msg.lower():
+            print(f"  {YELLOW}Fix{RESET}: Newer Claude models require a cross-region inference profile.")
+            print(f"  Direct model IDs (e.g. us.anthropic.claude-3-5-haiku-20241022-v1:0) cannot be")
+            print(f"  invoked on-demand — use the us.* inference profile instead:")
+            print(f"  Correct:   us.anthropic.claude-3-5-haiku-20241022-v1:0")
+            print(f"  Incorrect: anthropic.claude-3-5-haiku-20241022-v1:0\n")
+
+        elif code in ("ResourceNotFoundException", "ValidationException"):
+            print(f"  {YELLOW}Fix{RESET}: Model '{MODEL_ID}' not found in {REGION}.")
+            print(f"  Check that the model ID is correct and available in this region.\n")
+
+        print(f"  {RED}FAILED{RESET}\n")
+        return 1
+
+    except Exception as exc:  # noqa: BLE001
+        print(f"  {RED}✗{RESET}  Unexpected error: {exc}\n")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/parse_document/app.py
+++ b/src/parse_document/app.py
@@ -28,6 +28,7 @@ from datetime import datetime, timezone
 from urllib.parse import urlparse
 
 import boto3
+import fitz  # PyMuPDF
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver
 from aws_lambda_powertools.utilities.typing import LambdaContext
@@ -80,36 +81,54 @@ def _fetch_pdf_bytes(s3_uri: str) -> bytes:
     return response["Body"].read()
 
 
+_MAX_PDF_PAGES = 20
+
+
+def _pdf_to_page_images(pdf_bytes: bytes) -> list[bytes]:
+    """
+    Render each page of a PDF to a JPEG image.
+
+    Newer Claude models (3.5+) require cross-region inference profiles (us.*),
+    which do not support document blocks — they silently return empty responses.
+    Sending pages as image blocks is the workaround; image blocks work fine
+    with cross-region inference profiles.
+    """
+    doc = fitz.open(stream=pdf_bytes, filetype="pdf")
+    images = []
+    for page_num in range(min(doc.page_count, _MAX_PDF_PAGES)):
+        page = doc.load_page(page_num)
+        pix  = page.get_pixmap(matrix=fitz.Matrix(1.5, 1.5))
+        images.append(pix.tobytes("jpeg"))
+    doc.close()
+    return images
+
+
 def _call_bedrock(pdf_bytes: bytes) -> dict:
     """
-    Send the PDF to Bedrock via the Converse API and return the parsed JSON dict.
+    Send PDF pages as JPEG images to Bedrock and return the parsed JSON dict.
 
-    Uses a document block — requires a direct regional model ID
-    (e.g. anthropic.claude-3-5-haiku-20241022-v1:0).  Cross-region inference
-    profiles (us.*) do not support document blocks and silently return empty
-    responses; use the direct ID to avoid this.
+    Image blocks are used instead of a document block because:
+    - Newer Claude models (3.5+) require cross-region inference profiles (us.*)
+    - Cross-region inference profiles do not support document blocks
+    - Image blocks work correctly with cross-region inference profiles
 
     The model is expected to return a single JSON object — no markdown fences.
     If the response contains a fenced code block we strip the fences first.
     """
+    page_images = _pdf_to_page_images(pdf_bytes)
+    if not page_images:
+        raise ValueError("PDF produced no pages")
+
+    content = [
+        {"image": {"format": "jpeg", "source": {"bytes": img}}}
+        for img in page_images
+    ]
+    content.append({"text": USER_PROMPT})
+
     response = _bedrock.converse(
         modelId=_model_id,
         system=[{"text": SYSTEM_PROMPT}],
-        messages=[
-            {
-                "role": "user",
-                "content": [
-                    {
-                        "document": {
-                            "format": "pdf",
-                            "name":   "probate-filing",
-                            "source": {"bytes": pdf_bytes},
-                        },
-                    },
-                    {"text": USER_PROMPT},
-                ],
-            }
-        ],
+        messages=[{"role": "user", "content": content}],
         inferenceConfig={
             "maxTokens": 1024,
             "temperature": 0,

--- a/src/parse_document/requirements.txt
+++ b/src/parse_document/requirements.txt
@@ -1,2 +1,3 @@
 aws-lambda-powertools>=2.30.0
 boto3>=1.34.0
+PyMuPDF>=1.24.0

--- a/template.yaml
+++ b/template.yaml
@@ -63,12 +63,14 @@ Parameters:
 
   BedrockModelId:
     Type: String
-    Default: "anthropic.claude-3-5-haiku-20241022-v1:0"
+    Default: "us.anthropic.claude-3-5-haiku-20241022-v1:0"
     Description: >
       Amazon Bedrock model ID used by ParseDocumentFunction.
-      Use the direct regional ID (e.g. anthropic.claude-3-5-haiku-20241022-v1:0)
-      rather than a cross-region inference profile (us.*) — document blocks are
-      not supported with cross-region inference profiles.
+      Newer Claude models (3.5+) require a cross-region inference profile (us.*)
+      because on-demand throughput is not supported for them.  Document blocks
+      are not supported with cross-region inference, so PDFs are sent as per-page
+      JPEG images instead (see _pdf_to_page_images in src/parse_document/app.py).
+      Run "make check-bedrock" to verify access before deploying.
 
 # ---------------------------------------------------------------------------
 # Conditions

--- a/tests/test_parse_document.py
+++ b/tests/test_parse_document.py
@@ -156,10 +156,21 @@ class TestParseDocument(unittest.TestCase):
         self.mock_s3      = MagicMock()
         self.mock_bedrock = MagicMock()
 
-        parse_app._table   = self.mock_table
-        parse_app._s3      = self.mock_s3
-        parse_app._bedrock = self.mock_bedrock
-        parse_app._model_id = "anthropic.claude-3-5-haiku-20241022-v1:0"
+        parse_app._table    = self.mock_table
+        parse_app._s3       = self.mock_s3
+        parse_app._bedrock  = self.mock_bedrock
+        parse_app._model_id = "us.anthropic.claude-3-5-haiku-20241022-v1:0"
+
+        # Stub _pdf_to_page_images so tests don't need a real PDF / PyMuPDF.
+        self._page_images_patcher = patch.object(
+            parse_app,
+            "_pdf_to_page_images",
+            return_value=[b"fake-jpeg-page-1"],
+        )
+        self._page_images_patcher.start()
+
+    def tearDown(self):
+        self._page_images_patcher.stop()
 
     # ── 404 — lead not found ────────────────────────────────────────────────
 
@@ -346,10 +357,11 @@ class TestParseDocument(unittest.TestCase):
             Key="documents/CollinTx/20240001.pdf",
         )
 
-    # ── Bedrock PDF bytes forwarded via document block ───────────────────────
+    # ── Bedrock receives image blocks (cross-region inference workaround) ───────
+    # Document blocks are NOT supported with cross-region inference profiles
+    # (us.*).  The fix renders each PDF page to a JPEG and sends image blocks.
 
-    def test_pdf_bytes_forwarded_to_bedrock(self):
-        pdf_content = b"%PDF-1.4 fake content"
+    def test_page_images_forwarded_to_bedrock_as_image_blocks(self):
         lead = _make_lead()
         self.mock_table.get_item.side_effect = [
             {"Item": lead},
@@ -359,16 +371,27 @@ class TestParseDocument(unittest.TestCase):
                       "parse_error": ""}},
         ]
         self.mock_s3.get_object.return_value = {
-            "Body": MagicMock(read=MagicMock(return_value=pdf_content))
+            "Body": MagicMock(read=MagicMock(return_value=b"%PDF-1.4 fake"))
         }
         self.mock_bedrock.converse.return_value = _bedrock_response(_GOOD_BEDROCK_PAYLOAD)
 
         parse_app.parse_document("20240001")
 
-        converse_call = self.mock_bedrock.converse.call_args.kwargs
-        doc_block = converse_call["messages"][0]["content"][0]["document"]
-        self.assertEqual(doc_block["source"]["bytes"], pdf_content)
-        self.assertEqual(doc_block["format"], "pdf")
+        converse_call  = self.mock_bedrock.converse.call_args.kwargs
+        content_blocks = converse_call["messages"][0]["content"]
+
+        # First block must be an image block (not a document block)
+        first = content_blocks[0]
+        self.assertIn("image", first, f"Expected image block, got: {first}")
+        self.assertEqual(first["image"]["format"], "jpeg")
+        self.assertEqual(first["image"]["source"]["bytes"], b"fake-jpeg-page-1")
+
+        # Last block must be the text prompt
+        self.assertIn("text", content_blocks[-1])
+
+        # No document blocks anywhere
+        for block in content_blocks:
+            self.assertNotIn("document", block, "document block found — use image blocks")
 
     # ── Null fields from Bedrock are handled gracefully ──────────────────────
 


### PR DESCRIPTION
## Summary

Adds `POST /real-estate/probate-leads/leads/{lead_id}/parse-document` — a new Lambda that fetches a scraped PDF from S3, sends it to Amazon Bedrock (Claude 3.5 Haiku), and extracts structured probate data back into the leads table.

- New fields on the lead: `parsedAt`, `parsedModel`, `deceasedName`, `deceasedDob`, `deceasedDod`, `deceasedLastAddress`, `people`, `realProperty`, `summary`, `parseError`
- Separate Lambda (`ParseDocumentFunction`) with its own 120s timeout and scoped IAM (DynamoDB GetItem/UpdateItem, S3 GetObject, Bedrock InvokeModel)
- Available locally via `local_api_server.py`

## Key Bedrock constraints discovered during development

| Constraint | Detail |
|---|---|
| Claude 3.5+ requires a cross-region inference profile | `us.*` model ID is mandatory — direct on-demand invocation throws `ValidationException` |
| Cross-region profiles don't support document blocks | PDF sent as a `document` block silently returns empty fields |
| Image blocks work with cross-region profiles | Per-page JPEGs via PyMuPDF is the correct approach |

## New script

`scripts/check_bedrock.py` (`make check-bedrock`) — pre-deploy smoke test that invokes the model with a minimal prompt and prints actionable guidance for each failure mode (use-case-details form, on-demand-not-supported, IAM).

## Test plan

- [x] 209 unit tests pass (`make test`)
- [x] `make check-bedrock` returns PASSED (model access confirmed)
- [ ] Deploy and call `POST .../leads/2026000023696/parse-document`
- [ ] Verify `deceasedName`, `people`, `realProperty` are populated in response

🤖 Generated with [Claude Code](https://claude.com/claude-code)