### PR TITLE
fix: switch to Claude 3 Haiku with document blocks

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,7 +12,6 @@ webdriver-manager = ">=4.0.0"
 openpyxl = ">=3.1.0"
 boto3 = "*"
 aws-lambda-powertools = "*"
-PyMuPDF = "*"
 
 [dev-packages]
 ipykernel = "*"

--- a/scripts/check_bedrock.py
+++ b/scripts/check_bedrock.py
@@ -9,12 +9,12 @@ Usage:
     pipenv run python scripts/check_bedrock.py
 
     # Override model or region:
-    BEDROCK_MODEL_ID=us.anthropic.claude-3-5-haiku-20241022-v1:0 \\
+    BEDROCK_MODEL_ID=anthropic.claude-3-haiku-20240307-v1:0 \\
     AWS_DEFAULT_REGION=us-east-1 \\
     pipenv run python scripts/check_bedrock.py
 
 Environment variables:
-    BEDROCK_MODEL_ID   Model to test (default: us.anthropic.claude-3-5-haiku-20241022-v1:0)
+    BEDROCK_MODEL_ID   Model to test (default: anthropic.claude-3-haiku-20240307-v1:0)
     AWS_DEFAULT_REGION AWS region    (default: us-east-1)
 """
 
@@ -26,7 +26,7 @@ from botocore.exceptions import ClientError, NoCredentialsError
 
 MODEL_ID = os.environ.get(
     "BEDROCK_MODEL_ID",
-    "us.anthropic.claude-3-5-haiku-20241022-v1:0",
+    "anthropic.claude-3-haiku-20240307-v1:0",
 )
 REGION = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
 
@@ -75,7 +75,7 @@ def main() -> int:
             print("  Steps:")
             print(f"    1. Open the Bedrock model catalog:")
             print(f"       https://{REGION}.console.aws.amazon.com/bedrock/home?region={REGION}#/model-catalog")
-            print(f"    2. Search for 'Claude 3.5 Haiku'")
+            print(f"    2. Search for 'Claude 3 Haiku'")
             print(f"    3. Click the model → complete the use case details form")
             print(f"    4. Wait for approval (usually instant) then re-run: make check-bedrock\n")
 
@@ -85,11 +85,9 @@ def main() -> int:
             print(f'    {{"Effect": "Allow", "Action": "bedrock:InvokeModel", "Resource": "*"}}\n')
 
         elif code == "ValidationException" and "on-demand throughput" in msg.lower():
-            print(f"  {YELLOW}Fix{RESET}: Newer Claude models require a cross-region inference profile.")
-            print(f"  Direct model IDs (e.g. us.anthropic.claude-3-5-haiku-20241022-v1:0) cannot be")
-            print(f"  invoked on-demand — use the us.* inference profile instead:")
-            print(f"  Correct:   us.anthropic.claude-3-5-haiku-20241022-v1:0")
-            print(f"  Incorrect: anthropic.claude-3-5-haiku-20241022-v1:0\n")
+            print(f"  {YELLOW}Fix{RESET}: This model requires a cross-region inference profile (us.* prefix).")
+            print(f"  Claude 3 Haiku supports on-demand; if you see this the model ID is wrong.")
+            print(f"  Expected: anthropic.claude-3-haiku-20240307-v1:0\n")
 
         elif code in ("ResourceNotFoundException", "ValidationException"):
             print(f"  {YELLOW}Fix{RESET}: Model '{MODEL_ID}' not found in {REGION}.")

--- a/src/parse_document/app.py
+++ b/src/parse_document/app.py
@@ -8,7 +8,7 @@ Flow:
   1. Look up the lead by doc_number (lead_id) in DynamoDB.
   2. Verify it has a doc_s3_uri pointing to the stored PDF.
   3. Fetch the PDF bytes from S3.
-  4. Send the PDF to Amazon Bedrock (Claude 3.5 Haiku) via the Converse API
+  4. Send the PDF to Amazon Bedrock (Claude 3 Haiku) via the Converse API
      together with a structured-extraction prompt.
   5. Parse the JSON response from Bedrock.
   6. Persist the extracted fields back to the leads table via UpdateItem.
@@ -17,7 +17,7 @@ Flow:
 Environment variables:
   DYNAMO_TABLE_NAME   — leads table (default: leads)
   DOCUMENTS_BUCKET    — S3 bucket where PDFs are stored
-  BEDROCK_MODEL_ID    — Bedrock model ID (default: us.anthropic.claude-3-5-haiku-20241022-v1:0)
+  BEDROCK_MODEL_ID    — Bedrock model ID (default: anthropic.claude-3-haiku-20240307-v1:0)
   AWS_DEFAULT_REGION  — AWS region (injected by Lambda runtime)
 """
 
@@ -28,7 +28,6 @@ from datetime import datetime, timezone
 from urllib.parse import urlparse
 
 import boto3
-import fitz  # PyMuPDF
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver
 from aws_lambda_powertools.utilities.typing import LambdaContext
@@ -47,7 +46,7 @@ _table_name   = os.environ.get("DYNAMO_TABLE_NAME", "leads")
 _bucket_name  = os.environ.get("DOCUMENTS_BUCKET", "")
 _model_id     = os.environ.get(
     "BEDROCK_MODEL_ID",
-    "us.anthropic.claude-3-5-haiku-20241022-v1:0",
+    "anthropic.claude-3-haiku-20240307-v1:0",
 )
 
 _dynamodb = boto3.resource("dynamodb", region_name=_region)
@@ -81,54 +80,36 @@ def _fetch_pdf_bytes(s3_uri: str) -> bytes:
     return response["Body"].read()
 
 
-_MAX_PDF_PAGES = 20
-
-
-def _pdf_to_page_images(pdf_bytes: bytes) -> list[bytes]:
-    """
-    Render each page of a PDF to a JPEG image.
-
-    Newer Claude models (3.5+) require cross-region inference profiles (us.*),
-    which do not support document blocks — they silently return empty responses.
-    Sending pages as image blocks is the workaround; image blocks work fine
-    with cross-region inference profiles.
-    """
-    doc = fitz.open(stream=pdf_bytes, filetype="pdf")
-    images = []
-    for page_num in range(min(doc.page_count, _MAX_PDF_PAGES)):
-        page = doc.load_page(page_num)
-        pix  = page.get_pixmap(matrix=fitz.Matrix(1.5, 1.5))
-        images.append(pix.tobytes("jpeg"))
-    doc.close()
-    return images
-
-
 def _call_bedrock(pdf_bytes: bytes) -> dict:
     """
-    Send PDF pages as JPEG images to Bedrock and return the parsed JSON dict.
+    Send the PDF to Bedrock via the Converse API and return the parsed JSON dict.
 
-    Image blocks are used instead of a document block because:
-    - Newer Claude models (3.5+) require cross-region inference profiles (us.*)
-    - Cross-region inference profiles do not support document blocks
-    - Image blocks work correctly with cross-region inference profiles
+    Uses a document block with Claude 3 Haiku, which is available on-demand
+    (no cross-region inference profile required) and supports document blocks
+    natively.  Newer Claude models (3.5+) require us.* inference profiles that
+    support neither document blocks nor image blocks via Converse.
 
     The model is expected to return a single JSON object — no markdown fences.
     If the response contains a fenced code block we strip the fences first.
     """
-    page_images = _pdf_to_page_images(pdf_bytes)
-    if not page_images:
-        raise ValueError("PDF produced no pages")
-
-    content = [
-        {"image": {"format": "jpeg", "source": {"bytes": img}}}
-        for img in page_images
-    ]
-    content.append({"text": USER_PROMPT})
-
     response = _bedrock.converse(
         modelId=_model_id,
         system=[{"text": SYSTEM_PROMPT}],
-        messages=[{"role": "user", "content": content}],
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "document": {
+                            "format": "pdf",
+                            "name":   "probate-filing",
+                            "source": {"bytes": pdf_bytes},
+                        },
+                    },
+                    {"text": USER_PROMPT},
+                ],
+            }
+        ],
         inferenceConfig={
             "maxTokens": 1024,
             "temperature": 0,

--- a/src/parse_document/requirements.txt
+++ b/src/parse_document/requirements.txt
@@ -1,3 +1,2 @@
 aws-lambda-powertools>=2.30.0
 boto3>=1.34.0
-PyMuPDF>=1.24.0

--- a/template.yaml
+++ b/template.yaml
@@ -63,13 +63,13 @@ Parameters:
 
   BedrockModelId:
     Type: String
-    Default: "us.anthropic.claude-3-5-haiku-20241022-v1:0"
+    Default: "anthropic.claude-3-haiku-20240307-v1:0"
     Description: >
       Amazon Bedrock model ID used by ParseDocumentFunction.
-      Newer Claude models (3.5+) require a cross-region inference profile (us.*)
-      because on-demand throughput is not supported for them.  Document blocks
-      are not supported with cross-region inference, so PDFs are sent as per-page
-      JPEG images instead (see _pdf_to_page_images in src/parse_document/app.py).
+      Claude 3 Haiku is available on-demand (no inference profile required) and
+      supports document blocks natively, making it the simplest integration path.
+      Newer Claude models (3.5+) require cross-region inference profiles (us.*)
+      which support neither document blocks nor image blocks via Converse.
       Run "make check-bedrock" to verify access before deploying.
 
 # ---------------------------------------------------------------------------

--- a/tests/test_parse_document.py
+++ b/tests/test_parse_document.py
@@ -159,18 +159,7 @@ class TestParseDocument(unittest.TestCase):
         parse_app._table    = self.mock_table
         parse_app._s3       = self.mock_s3
         parse_app._bedrock  = self.mock_bedrock
-        parse_app._model_id = "us.anthropic.claude-3-5-haiku-20241022-v1:0"
-
-        # Stub _pdf_to_page_images so tests don't need a real PDF / PyMuPDF.
-        self._page_images_patcher = patch.object(
-            parse_app,
-            "_pdf_to_page_images",
-            return_value=[b"fake-jpeg-page-1"],
-        )
-        self._page_images_patcher.start()
-
-    def tearDown(self):
-        self._page_images_patcher.stop()
+        parse_app._model_id = "anthropic.claude-3-haiku-20240307-v1:0"
 
     # ── 404 — lead not found ────────────────────────────────────────────────
 
@@ -357,11 +346,10 @@ class TestParseDocument(unittest.TestCase):
             Key="documents/CollinTx/20240001.pdf",
         )
 
-    # ── Bedrock receives image blocks (cross-region inference workaround) ───────
-    # Document blocks are NOT supported with cross-region inference profiles
-    # (us.*).  The fix renders each PDF page to a JPEG and sends image blocks.
+    # ── Bedrock PDF bytes forwarded via document block ───────────────────────
 
-    def test_page_images_forwarded_to_bedrock_as_image_blocks(self):
+    def test_pdf_bytes_forwarded_to_bedrock(self):
+        pdf_content = b"%PDF-1.4 fake content"
         lead = _make_lead()
         self.mock_table.get_item.side_effect = [
             {"Item": lead},
@@ -371,27 +359,16 @@ class TestParseDocument(unittest.TestCase):
                       "parse_error": ""}},
         ]
         self.mock_s3.get_object.return_value = {
-            "Body": MagicMock(read=MagicMock(return_value=b"%PDF-1.4 fake"))
+            "Body": MagicMock(read=MagicMock(return_value=pdf_content))
         }
         self.mock_bedrock.converse.return_value = _bedrock_response(_GOOD_BEDROCK_PAYLOAD)
 
         parse_app.parse_document("20240001")
 
-        converse_call  = self.mock_bedrock.converse.call_args.kwargs
-        content_blocks = converse_call["messages"][0]["content"]
-
-        # First block must be an image block (not a document block)
-        first = content_blocks[0]
-        self.assertIn("image", first, f"Expected image block, got: {first}")
-        self.assertEqual(first["image"]["format"], "jpeg")
-        self.assertEqual(first["image"]["source"]["bytes"], b"fake-jpeg-page-1")
-
-        # Last block must be the text prompt
-        self.assertIn("text", content_blocks[-1])
-
-        # No document blocks anywhere
-        for block in content_blocks:
-            self.assertNotIn("document", block, "document block found — use image blocks")
+        converse_call = self.mock_bedrock.converse.call_args.kwargs
+        doc_block = converse_call["messages"][0]["content"][0]["document"]
+        self.assertEqual(doc_block["source"]["bytes"], pdf_content)
+        self.assertEqual(doc_block["format"], "pdf")
 
     # ── Null fields from Bedrock are handled gracefully ──────────────────────
 


### PR DESCRIPTION
## Problem

Claude 3.5+ cross-region inference profiles (`us.*`) support **neither** document blocks nor image blocks via Bedrock Converse — making them unusable for PDF extraction regardless of approach.

| Method | Result |
|---|---|
| `us.*` + document block | 200 response, all fields empty (silently ignored) |
| `us.*` + image blocks | `ValidationException: model doesn't support image content block` |
| Direct model ID (no `us.*`) | `ValidationException: on-demand throughput isn't supported` |

## Fix

Switch to **Claude 3 Haiku** (`anthropic.claude-3-haiku-20240307-v1:0`), which is available on-demand (no inference profile required) and supports document blocks natively.

- ~3× cheaper than Claude 3.5 Haiku: ~$0.007/doc vs ~$0.022/doc
- Simpler code: no PyMuPDF, no image conversion, clean document block

## Changes

- `template.yaml`: `BedrockModelId` default → `anthropic.claude-3-haiku-20240307-v1:0`
- `src/parse_document/app.py`: remove PyMuPDF / image-block approach; restore document block
- `src/parse_document/requirements.txt`: remove `PyMuPDF>=1.24.0`
- `Pipfile`: remove PyMuPDF
- `tests/test_parse_document.py`: remove patcher; restore document block assertion
- `scripts/check_bedrock.py`: update default model ID and guidance text

## Test plan

- [x] 209 unit tests pass (`make test`)
- [x] `make check-bedrock` returns PASSED
- [ ] Deploy and call `POST .../leads/2026000023696/parse-document` — expect populated fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)