### PR TITLE
fix: robust JSON extraction from Bedrock response

### DIFF
--- a/src/parse_document/app.py
+++ b/src/parse_document/app.py
@@ -118,12 +118,30 @@ def _call_bedrock(pdf_bytes: bytes) -> dict:
 
     raw_text = response["output"]["message"]["content"][0]["text"].strip()
 
-    # Strip optional ```json ... ``` fences
+    # 1. Try parsing as-is (ideal: model returned pure JSON)
+    try:
+        return json.loads(raw_text)
+    except json.JSONDecodeError:
+        pass
+
+    # 2. Strip optional ```json ... ``` fences then retry
     fenced = re.match(r"^```(?:json)?\s*(.*?)\s*```$", raw_text, re.DOTALL)
     if fenced:
-        raw_text = fenced.group(1).strip()
+        try:
+            return json.loads(fenced.group(1).strip())
+        except json.JSONDecodeError:
+            pass
 
-    return json.loads(raw_text)
+    # 3. Slice from the first '{' to the last '}' — handles preamble/postamble prose
+    start = raw_text.find("{")
+    end   = raw_text.rfind("}")
+    if start != -1 and end > start:
+        try:
+            return json.loads(raw_text[start : end + 1])
+        except json.JSONDecodeError:
+            pass
+
+    raise ValueError(f"No valid JSON in model response: {raw_text[:300]!r}")
 
 
 def _persist_parsed_fields(lead_id: str, parsed: dict, model_id: str, error: str = "") -> None:

--- a/tests/test_parse_document.py
+++ b/tests/test_parse_document.py
@@ -304,6 +304,26 @@ class TestParseDocument(unittest.TestCase):
         self.assertEqual(status, 200)
         self.assertEqual(body["deceasedName"], "Jane A. Smith")
 
+    def test_preamble_prose_before_json_is_handled(self):
+        """Model sometimes adds prose before the JSON — slice from first { to last }."""
+        preamble = f"Here is the extracted information:\n{json.dumps(_GOOD_BEDROCK_PAYLOAD)}"
+        lead     = _make_lead()
+        self.mock_table.get_item.side_effect = [
+            {"Item": lead},
+            {"Item": {**lead, **_GOOD_BEDROCK_PAYLOAD,
+                      "parsed_at": "2026-02-26T00:00:00+00:00",
+                      "parsed_model": parse_app._model_id,
+                      "parse_error": ""}},
+        ]
+        self.mock_s3.get_object.return_value = {
+            "Body": MagicMock(read=MagicMock(return_value=b"%PDF fake"))
+        }
+        self.mock_bedrock.converse.return_value = _bedrock_response(preamble)
+
+        body, status = parse_app.parse_document("20240001")
+        self.assertEqual(status, 200)
+        self.assertEqual(body["deceasedName"], "Jane A. Smith")
+
     def test_plain_fenced_block_no_language_tag(self):
         fenced = f"```\n{json.dumps(_GOOD_BEDROCK_PAYLOAD)}\n```"
         lead   = _make_lead()


### PR DESCRIPTION
## Problem

Claude 3 Haiku sometimes prefixes the JSON with a prose line (e.g. `"Here is the extracted information:\n{...}"`) despite the system prompt asking for JSON-only output. The single `json.loads()` call fails with:

```
Expecting ':' delimiter: line 2 column 5 (char 6)
```

## Fix

Replace the single parse attempt with a 3-step extraction in `_call_bedrock`:

1. `json.loads(raw_text)` — ideal path, model returned pure JSON
2. Strip ` ```json ... ``` ` fences and retry — handles markdown-wrapped responses  
3. Slice `raw_text[first '{' : last '}' + 1]` and retry — handles arbitrary preamble/postamble prose

Raises `ValueError` with a response excerpt if all three fail (surfaces cleanly as a 500 with `parseError` set).

## Test plan

- [x] 210 unit tests pass (`make test`)
- [x] `test_preamble_prose_before_json_is_handled` covers the new step 3 path
- [ ] Deploy and re-test `POST .../leads/2026000023696/parse-document`

🤖 Generated with [Claude Code](https://claude.com/claude-code)