### PR TITLE
fix: pin BedrockModelId in samconfig.toml to Claude 3 Haiku

### DIFF
--- a/samconfig.toml
+++ b/samconfig.toml
@@ -32,6 +32,7 @@ parameter_overrides = """
   ScrapeSchedule=cron(0 6 * * ? *)
   ScraperUsername=REPLACE_ME
   ScraperPassword=REPLACE_ME
+  BedrockModelId=anthropic.claude-3-haiku-20240307-v1:0
 """
 # ── Sensitive values (keep out of version control) ────────────────────────
 # ScraperPassword has NoEcho=true in template.yaml so it won't appear in the


### PR DESCRIPTION
## Problem

CloudFormation retains existing parameter values when a parameter is omitted from `parameter_overrides` — the template's new `Default` is only used on the very **first** stack creation. The stack was silently keeping `us.anthropic.claude-3-5-haiku-20241022-v1:0` from an earlier deploy, even after PR #30 changed the template default to Claude 3 Haiku.

## Fix

Add `BedrockModelId=anthropic.claude-3-haiku-20240307-v1:0` explicitly to `samconfig.toml`'s `parameter_overrides` so every `sam deploy` passes the correct value.

## Test plan

- [ ] Merge & wait for GitHub Actions deploy to complete
- [ ] `POST .../leads/2026000023696/parse-document`
- [ ] Confirm `parsedModel` = `"anthropic.claude-3-haiku-20240307-v1:0"`
- [ ] Confirm `deceasedName` and other fields are populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)