### PR TITLE
fix: rename LeadsTable to leads-v2 to unblock CF deployment

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -124,14 +124,14 @@ Resources:
         RestrictPublicBuckets: true
 
   # ── DynamoDB — Leads ──────────────────────────────────────────────────────
-  # NOTE: renamed from probate-leads-collin-tx → leads.
-  # CloudFormation will replace (delete + recreate) the table on first deploy.
+  # NOTE: renamed leads → leads-v2 to change the PK from doc_number → lead_id.
+  # CloudFormation requires a name change when replacing a custom-named table.
   # Migrate data before deploying if the live table has records you need.
 
   LeadsTable:
     Type: AWS::DynamoDB::Table
     Properties:
-      TableName: leads
+      TableName: leads-v2
       BillingMode: PAY_PER_REQUEST
       AttributeDefinitions:
         - AttributeName: lead_id


### PR DESCRIPTION
## Summary

- CloudFormation failed to deploy the `lead_id` PK change because it cannot replace a custom-named DynamoDB table in-place — it would need to hold two tables named `leads` simultaneously
- Renaming `TableName: leads` → `TableName: leads-v2` lets CF create the new table alongside the old one, then delete the old one
- All `DYNAMO_TABLE_NAME` env vars are `!Ref LeadsTable` throughout the template, so they resolve to `leads-v2` automatically after deploy — no manual env var changes needed
- Local dev is unaffected (`seed_local.py` uses its own hardcoded `leads` name)

## Test plan

- [ ] `make test` — all 232 tests pass
- [ ] Re-run the failed CI deploy — CloudFormation changeset should now show `Replace: True` on LeadsTable and complete successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)