### PR TITLE
fix: skip already-downloaded rows instead of breaking Phase 2 early

### DIFF
--- a/src/scraper/scraper.py
+++ b/src/scraper/scraper.py
@@ -836,7 +836,7 @@ def extract_page_data(
             recent_total += 1
 
             if doc_number in already_downloaded:
-                break  # doc already in S3 — no further downloads needed
+                continue  # already has a doc in S3; keep scanning for newer ones
 
             if downloads_done >= max_downloads:
                 log.debug("Row %d: download limit (%d) reached — skipping", entry["index"], max_downloads)


### PR DESCRIPTION
## Summary
- `break` on `already_downloaded` caused Phase 2 to exit immediately when the first row already had a doc in S3
- Production logs showed "1 record(s) in past 30 days" when there were actually 20, because `recent_total` only reached 1 before the early exit
- The document fetch never reached row 3 even though rows 1–2 were the only ones already downloaded

## Fix
Change `break` → `continue` for the `already_downloaded` check so the loop skips that row and keeps scanning. The `break` on an old `recorded_date` is unchanged (rows are newest-first, so one old row means all remaining rows are older too).

## Test plan
- [ ] All 232 existing tests pass (`make test`)
- [ ] Deploy and verify production logs show ~20 recent records and downloads begin at the first row not already in S3

🤖 Generated with [Claude Code](https://claude.com/claude-code)