### PR TITLE
feat: rename subscribers→users + add passwordless magic-link auth

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -204,6 +204,14 @@ jobs:
               print("CollinTx already exists — skipping")
           EOF
 
+      # ── Wait for API Gateway deployment to propagate ───────────────────────
+      # API Gateway stage updates can take up to ~30 s after CloudFormation
+      # reports success.  Without this pause, early smoke-test requests can hit
+      # a transitional state where routes return 403 "Missing Authentication
+      # Token" instead of reaching Lambda.
+      - name: Wait for API Gateway propagation
+        run: sleep 30
+
       # ── Python env for smoke tests ─────────────────────────────────────────
       - name: Set up Python 3.13
         uses: actions/setup-python@v5

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -19,6 +19,7 @@ import os
 import sys
 import uuid
 import json
+import time
 import datetime
 import requests
 
@@ -81,6 +82,11 @@ def check(name: str, condition: bool, details: str = "") -> bool:
 # HTTP helpers
 # ---------------------------------------------------------------------------
 
+_RETRY_STATUSES = {502, 503, 504}   # transient server errors worth retrying
+_MAX_RETRIES    = 3
+_RETRY_DELAY    = 5  # seconds between retries
+
+
 def _headers(require_key: bool = True) -> dict:
     h = {"Content-Type": "application/json"}
     if require_key:
@@ -88,22 +94,36 @@ def _headers(require_key: bool = True) -> dict:
     return h
 
 
+def _retry(fn, *args, **kwargs) -> requests.Response:
+    """Call *fn* up to _MAX_RETRIES times, retrying on transient server errors."""
+    for attempt in range(1, _MAX_RETRIES + 1):
+        r = fn(*args, **kwargs)
+        if r.status_code not in _RETRY_STATUSES:
+            return r
+        if attempt < _MAX_RETRIES:
+            print(f"       {YELLOW}⟳  HTTP {r.status_code} — retrying in {_RETRY_DELAY}s "
+                  f"(attempt {attempt}/{_MAX_RETRIES}){RESET}")
+            time.sleep(_RETRY_DELAY)
+    return r
+
+
 def get(path: str, params: dict | None = None) -> requests.Response:
-    return requests.get(f"{BASE}{path}", headers=_headers(), params=params, timeout=TIMEOUT)
+    return _retry(requests.get, f"{BASE}{path}", headers=_headers(), params=params, timeout=TIMEOUT)
 
 
 def post(path: str, body: dict, require_key: bool = True) -> requests.Response:
-    return requests.post(
-        f"{BASE}{path}", headers=_headers(require_key), json=body, timeout=TIMEOUT
+    return _retry(
+        requests.post,
+        f"{BASE}{path}", headers=_headers(require_key), json=body, timeout=TIMEOUT,
     )
 
 
 def patch(path: str, body: dict) -> requests.Response:
-    return requests.patch(f"{BASE}{path}", headers=_headers(), json=body, timeout=TIMEOUT)
+    return _retry(requests.patch, f"{BASE}{path}", headers=_headers(), json=body, timeout=TIMEOUT)
 
 
 def delete(path: str) -> requests.Response:
-    return requests.delete(f"{BASE}{path}", headers=_headers(), timeout=TIMEOUT)
+    return _retry(requests.delete, f"{BASE}{path}", headers=_headers(), timeout=TIMEOUT)
 
 
 def _snippet(r: requests.Response) -> str:


### PR DESCRIPTION
## Summary

- **Rename `subscribers` → `users`** across 18 files: DynamoDB table (`subscribers` → `users`, PK `subscriber_id` → `user_id`), all routes, models, tests, scripts, and CloudFormation template
- **Add passwordless magic-link auth** — `POST /auth/request-login` sends a 15-min signed JWT via SES; `GET /auth/verify` exchanges it for a 7-day access JWT; `GET/PATCH /auth/me` and `GET /auth/leads` let users manage their own data; `/admin/users/*` routes gated by admin Bearer token
- **Fix CI**: add `PyJWT` to `Pipfile` so `pipenv install --dev` installs it in GitHub Actions (it was only in `src/api/requirements.txt` for Lambda packaging)
- **Fix transient smoke-test 403s**: add `sleep 30` after `sam deploy` in deploy.yml to let API Gateway propagate, plus retry logic in `smoke_test.py` for 5xx errors

## New routes (all under `/real-estate/probate-leads/`, no API key required)

| Method | Path | Description |
|--------|------|-------------|
| `POST` | `/auth/request-login` | Send magic link to email (always 200, anti-enumeration) |
| `GET` | `/auth/verify?token=` | Exchange magic token → 7-day access JWT |
| `GET` | `/auth/me` | Own profile (Bearer token) |
| `PATCH` | `/auth/me` | Update own email (Bearer token) |
| `GET` | `/auth/leads` | Own leads across subscribed counties (Bearer, active only) |
| `GET` | `/admin/users` | List all users (admin Bearer) |
| `GET` | `/admin/users/{id}` | Get user (admin Bearer) |
| `PATCH` | `/admin/users/{id}` | Update role / status / location_codes (admin Bearer) |
| `DELETE` | `/admin/users/{id}` | Soft-delete → inactive (admin Bearer) |

## New CloudFormation parameters

| Parameter | Notes |
|-----------|-------|
| `JwtSecret` | HMAC-SHA256 secret (`NoEcho: true`) |
| `MagicLinkBaseUrl` | Base URL prepended to the verify token |
| `FromEmail` | SES verified sender; leave blank → magic link logged to console |

## ⚠️ Breaking changes

- DynamoDB `subscribers` table is **replaced** by `users` (CloudFormation will delete + recreate). Export production data before deploying.
- All `subscriberId` response fields renamed to `userId`.

## Test plan

- [x] 284 unit tests pass locally (`make test`)
- [x] CI unit tests pass (PyJWT in Pipfile)
- [x] Smoke tests pass 41/41 against production
- [ ] Deploy to staging and verify magic-link email arrives via SES
- [ ] Verify admin routes reject non-admin Bearer tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)