### PR TITLE
docs: rewrite README with UI, auth, and custom domain info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Probate Leads
 
-Scrapes probate records from county public-records portals and exposes them via a REST API with Stripe-backed subscriptions. Built on AWS (ECS Fargate + Lambda + DynamoDB + API Gateway).
+Scrapes probate records from county public-records portals and exposes them via a REST API with magic-link auth and Stripe-backed subscriptions. Built on AWS (ECS Fargate + Lambda + DynamoDB + API Gateway + CloudFront).
+
+Live at **[collincountyleads.com](https://collincountyleads.com)**.
 
 ## Architecture
 
@@ -14,21 +16,28 @@ ECS Fargate — Selenium scraper (Docker)
 DynamoDB
   ├── leads          (doc_number PK | location-date-index GSI)
   ├── locations      (location_code PK | location-path-index GSI)
-  └── subscribers    (subscriber_id PK | email-index GSI)
+  └── users          (user_id PK | email-index GSI)
     │
     ▼
-API Gateway (API key auth)
+API Gateway (api.collincountyleads.com)
     │
     ├── Lambda ApiFunction
     │     GET  /{location_path}/leads
     │     GET  /locations
     │     GET  /locations/{location_code}
-    │     GET/POST  /subscribers
-    │     GET/PATCH/DELETE  /subscribers/{subscriber_id}
-    │     POST /stripe/webhook  (no API key — Stripe signature)
+    │     GET/POST/PATCH/DELETE  /users
+    │     POST /auth/request-login   (magic link)
+    │     GET  /auth/verify          (exchange token)
+    │     GET/PATCH  /auth/me        (own profile)
+    │     GET  /auth/leads           (own leads)
+    │     GET/PATCH/DELETE  /admin/users
+    │     POST /stripe/webhook       (no API key — Stripe signature)
     │
     └── Lambda TriggerFunction
           POST /{location_path}/update  → runs Fargate scrape task
+
+CloudFront (collincountyleads.com)
+    └── S3 — React SPA (Vite)
 ```
 
 All API paths are prefixed with `/real-estate/probate-leads/`.
@@ -39,7 +48,7 @@ All API paths are prefixed with `/real-estate/probate-leads/`.
 |---|---|---|---|
 | `leads` | `doc_number` | `recorded-date-index`, `location-date-index` | Scraped probate records |
 | `locations` | `location_code` | `location-path-index` | Supported counties |
-| `subscribers` | `subscriber_id` | `email-index` | Stripe-backed subscribers |
+| `users` | `user_id` | `email-index` | Magic-link authenticated users |
 
 Leads carry a `location_code` FK. The `location-date-index` GSI (`location_code` HASH + `recorded_date` RANGE) is the primary query path.
 
@@ -51,11 +60,89 @@ Leads carry a `location_code` FK. The `location-date-index` GSI (`location_code`
 
 Add new counties by inserting a row in the `locations` table and deploying a new scraper task with the matching `LOCATION_CODE` env var.
 
+## UI
+
+The React SPA lives in `ui/` and is built with Vite + React + TailwindCSS + shadcn/ui.
+
+### Pages
+
+| Route | Component | Description |
+|---|---|---|
+| `/` | `Landing` | Marketing landing page |
+| `/login` | `Login` | Magic-link sign-in form |
+| `/auth/verify` | `AuthVerify` | Exchanges magic token for access token, redirects to dashboard |
+| `/dashboard` | `Dashboard` | Leads table with date-range filters and CSV export |
+| `/account` | `Account` | Edit email, view subscription status |
+| `/admin/users` | `admin/Users` | Admin: list and manage all users |
+| `/admin/users/:id` | `admin/UserDetail` | Admin: view and edit a single user |
+
+### Key libraries
+
+| Library | Purpose |
+|---|---|
+| `react-router-dom` | Client-side routing |
+| `@tanstack/react-query` | Server state, caching, and request deduplication |
+| `react-hook-form` + `zod` | Form validation |
+| `@radix-ui/*` | Accessible UI primitives (via shadcn/ui) |
+| `lucide-react` | Icons |
+
+### Auth flow
+
+1. User submits email on `/login` → `POST /auth/request-login`
+2. API sends a magic link to the email (SES)
+3. User clicks the link → `/auth/verify?token=<jwt>`
+4. `AuthVerify` exchanges the token → API returns an access token stored in `localStorage`
+5. Authenticated requests use `Authorization: Bearer <token>`
+
+Tokens are short-lived JWTs signed with `JWT_SECRET`. Magic-link tokens expire in 15 minutes; access tokens expire in 7 days.
+
+### Local development
+
+```bash
+# 1. Start the backend (DynamoDB + API)
+make local-db-start
+make local-db-seed   # first time only
+make local-api-start # http://localhost:3000
+
+# 2. Start the UI dev server
+cd ui
+npm install
+npm run dev          # http://localhost:3001
+```
+
+The UI dev server reads `ui/.env.local`:
+
+```env
+VITE_API_URL=http://localhost:3000/real-estate/probate-leads
+VITE_API_KEY=                     # leave blank for local (no key required)
+```
+
+Magic links are printed to the local API server stdout (SES is skipped when `FROM_EMAIL` is unset).
+
+### Production build
+
+The CI/CD pipeline builds the UI automatically on push to `main`:
+
+```bash
+cd ui
+VITE_API_URL=https://api.collincountyleads.com/real-estate/probate-leads \
+VITE_API_KEY=<api-gateway-key> \
+npm run build
+# Output: ui/dist/
+```
+
+To deploy the UI manually:
+
+```bash
+make deploy-ui   # sync ui/dist/ to S3 + invalidate CloudFront
+```
+
 ## Local Development
 
 ### Prerequisites
 - Docker Desktop (for DynamoDB Local)
 - Python 3.12+ with pipenv
+- Node.js 18+ (for the UI)
 - AWS CLI (configured with any credentials for local use)
 
 ### Start the local stack
@@ -85,26 +172,27 @@ curl $BASE/locations
 # Query leads
 curl "$BASE/collin-tx/leads?from_date=2026-01-01&to_date=2026-02-20&limit=10"
 
-# Create a subscriber
-curl -X POST $BASE/subscribers \
+# Request a magic link (token printed to stdout, email skipped locally)
+curl -X POST $BASE/auth/request-login \
   -H "Content-Type: application/json" \
-  -d '{"email":"you@example.com","location_codes":["CollinTx"],"stripe_customer_id":"cus_xxx"}'
+  -d '{"email":"you@example.com"}'
 
-# Update subscriber locations
-curl -X PATCH $BASE/subscribers/<subscriber_id> \
+# Create a user (admin)
+curl -X POST $BASE/users \
+  -H "x-api-key: <key>" \
   -H "Content-Type: application/json" \
-  -d '{"location_codes":["CollinTx"]}'
+  -d '{"email":"you@example.com","location_codes":["CollinTx"]}'
 ```
 
 ### Run tests
 
 ```bash
-make test   # 76 unit tests, no external services needed
+make test   # unit tests, no external services needed
 ```
 
 ## API Reference
 
-All routes require an `x-api-key` header except `POST /stripe/webhook`.
+All routes require an `x-api-key` header except `/auth/*` and `POST /stripe/webhook`.
 
 ### Leads
 
@@ -139,31 +227,40 @@ Response:
 | `GET` | `/locations` | List all locations |
 | `GET` | `/locations/{location_code}` | Get a single location |
 
-### Subscribers
+### Users
+
+| Method | Path | Auth | Description |
+|---|---|---|---|
+| `GET` | `/users` | API key | List all users |
+| `POST` | `/users` | API key | Create a user |
+| `GET` | `/users/{user_id}` | API key | Get a user |
+| `PATCH` | `/users/{user_id}` | API key | Update `location_codes` and/or `status` |
+| `DELETE` | `/users/{user_id}` | API key | Soft-delete (status → `inactive`) |
+
+User statuses: `active` | `inactive` | `canceled` | `past_due`
+
+### Auth
+
+No API key required. All auth routes are public.
 
 | Method | Path | Description |
 |---|---|---|
-| `GET` | `/subscribers` | List all subscribers |
-| `POST` | `/subscribers` | Create a subscriber |
-| `GET` | `/subscribers/{subscriber_id}` | Get a subscriber |
-| `PATCH` | `/subscribers/{subscriber_id}` | Update `location_codes` and/or `status` |
-| `DELETE` | `/subscribers/{subscriber_id}` | Soft-delete (status → `inactive`) |
+| `POST` | `/auth/request-login` | Send a magic link to the given email |
+| `GET` | `/auth/verify?token=<jwt>` | Exchange magic token for access token |
+| `GET` | `/auth/me` | Get own user profile (Bearer token) |
+| `PATCH` | `/auth/me` | Update own email (Bearer token) |
+| `GET` | `/auth/leads` | Get own leads (Bearer token, active users only) |
 
-#### `POST /subscribers` body
+### Admin
 
-```json
-{
-  "email": "user@example.com",
-  "location_codes": ["CollinTx"],
-  "stripe_customer_id": "cus_...",
-  "stripe_subscription_id": "sub_...",
-  "status": "active"
-}
-```
+Bearer token required, user must have `role: admin`.
 
-`location_codes` must be a non-empty list of valid `location_code` values.
-
-Subscriber statuses: `active` | `inactive` | `canceled` | `past_due` | `trialing`
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/admin/users` | List all users |
+| `GET` | `/admin/users/{user_id}` | Get a user |
+| `PATCH` | `/admin/users/{user_id}` | Update user |
+| `DELETE` | `/admin/users/{user_id}` | Soft-delete user |
 
 ### Stripe webhook
 
@@ -180,7 +277,7 @@ Handled events:
 | `customer.subscription.deleted` | `canceled` |
 | `invoice.payment_failed` | `past_due` |
 
-Subscribers are matched by `stripe_customer_id`.
+Users are matched by `stripe_customer_id`.
 
 ## Stripe Integration
 
@@ -188,26 +285,18 @@ Subscribers are matched by `stripe_customer_id`.
 
 1. Create a [Stripe account](https://dashboard.stripe.com) and grab your test keys from **Developers → API keys**.
 2. Register the webhook endpoint in **Developers → Webhooks → Add endpoint**:
-   - URL: `https://<api-id>.execute-api.us-east-1.amazonaws.com/prod/real-estate/probate-leads/stripe/webhook`
+   - URL: `https://api.collincountyleads.com/real-estate/probate-leads/stripe/webhook`
    - Events: `customer.subscription.created`, `customer.subscription.updated`, `customer.subscription.deleted`, `invoice.payment_failed`
 3. Copy the signing secret (`whsec_...`).
 
 ### Local testing with Stripe CLI
 
 ```bash
-# Install
-brew install stripe/stripe-cli/stripe
-
-# Authenticate
-stripe login
-
-# Forward Stripe events to local server (prints a webhook secret)
 stripe listen \
   --forward-to localhost:3000/real-estate/probate-leads/stripe/webhook
 
-# Trigger test events in a second terminal
+# In a second terminal
 stripe trigger customer.subscription.created
-stripe trigger customer.subscription.deleted
 stripe trigger invoice.payment_failed
 ```
 
@@ -217,17 +306,7 @@ Start the local API server with the webhook secret the CLI printed:
 STRIPE_WEBHOOK_SECRET=whsec_... make local-api-start
 ```
 
-> **Without `STRIPE_WEBHOOK_SECRET`** signature verification is skipped, so plain `curl` works for quick local testing (see [Local Development](#local-development) above).
-
-### Typical subscriber flow
-
-```
-1.  User subscribes via your frontend (Stripe Checkout / Elements)
-2.  Frontend gets stripe_customer_id + stripe_subscription_id from Stripe
-3.  Frontend calls POST /subscribers with those IDs + desired location_codes
-4.  Stripe sends webhook events → API auto-updates subscriber status
-5.  Your app checks subscriber.status before granting access to leads
-```
+> **Without `STRIPE_WEBHOOK_SECRET`** signature verification is skipped, so plain `curl` works for quick local testing.
 
 ## Deployment
 
@@ -240,20 +319,21 @@ make build-push
 
 # 2. Fill in samconfig.toml: VpcId, SubnetIds, ScraperImageUri
 
-# 3. Add Stripe keys (or leave empty to skip verification)
-# Edit samconfig.toml parameter_overrides:
-#   StripeSecretKey=sk_live_...
-#   StripeWebhookSecret=whsec_...
-
-# 4. Deploy
+# 3. Deploy infrastructure
 make deploy
+
+# 4. Build and deploy the UI
+make deploy-ui
 ```
 
 ### Subsequent deploys
 
+Push to `main` — GitHub Actions runs `ci.yml` (tests) then `deploy.yml` (SAM deploy + UI build + S3 sync).
+
 ```bash
-make deploy          # sam build + sam deploy
+make deploy          # manual: sam build + sam deploy
 make build-push      # rebuild + push scraper Docker image
+make deploy-ui       # manual: sync ui/dist/ to S3 + CloudFront invalidation
 ```
 
 ### Useful operations
@@ -265,36 +345,74 @@ make logs-api        # tail Lambda logs
 make get-api-key     # print the API Gateway key
 ```
 
-> ⚠️ **Data migration note:** the `leads` table was renamed from `probate-scraper-collin-tx`. CloudFormation will replace it on first deploy — export any data you need to keep before deploying.
+### Custom domain (collincountyleads.com)
+
+Infrastructure is configured for:
+
+| Record | Target |
+|---|---|
+| `collincountyleads.com` | CloudFront distribution (UI) |
+| `www.collincountyleads.com` | CloudFront distribution (UI) |
+| `api.collincountyleads.com` | API Gateway edge custom domain |
+
+All Cloudflare DNS records must be **DNS only (gray cloud)** — CloudFront handles SSL termination using the ACM certificate.
+
+SES is configured to send from `hello@collincountyleads.com`. The domain must be verified in SES (DKIM CNAMEs in Cloudflare) and the account must be out of SES sandbox before magic-link emails will deliver.
 
 ## Project Structure
 
 ```
+ui/
+  src/
+    pages/
+      Landing.tsx         # Marketing landing page
+      Login.tsx           # Magic-link sign-in
+      AuthVerify.tsx      # Token exchange + redirect
+      Dashboard.tsx       # Leads table
+      Account.tsx         # User profile
+      admin/
+        Users.tsx         # Admin user list
+        UserDetail.tsx    # Admin user detail
+    components/
+      leads-table.tsx     # Sortable/filterable leads table
+      login-form.tsx      # Email form
+      user-nav.tsx        # Avatar dropdown
+    lib/
+      api.ts              # Typed API client
+      auth.ts             # Token storage helpers
+      types.ts            # Shared TypeScript types
+      utils.ts            # cn() and other utilities
 src/
   api/
-    app.py              # Lambda handler — all API routes
-    stripe_helpers.py   # Stripe webhook signature verification
+    app.py                # Lambda handler — all API routes
+    routers/              # leads, locations, users, auth, admin, stripe
+    stripe_helpers.py     # Stripe webhook signature verification
     requirements.txt
   scraper/
-    app.py              # ECS entrypoint
-    scraper.py          # Selenium scraper
-    dynamo.py           # DynamoDB batch writer + location updater
+    app.py                # ECS entrypoint
+    scraper.py            # Selenium scraper
+    dynamo.py             # DynamoDB batch writer + location updater
     Dockerfile
     requirements.txt
   trigger/
-    app.py              # Lambda — starts Fargate scrape task
+    app.py                # Lambda — starts Fargate scrape task
     requirements.txt
+  parse_document/
+    app.py                # Lambda — Bedrock document parsing
 scripts/
-  seed_local.py         # Create tables + seed locations locally
-  local_api_server.py   # Dev HTTP server wrapping the Lambda handler
+  seed_local.py           # Create tables + seed locations locally
+  local_api_server.py     # Dev HTTP server wrapping the Lambda handler
+  smoke_test.py           # End-to-end smoke tests against deployed API
 tests/
-  fixtures/             # Mock leads, locations, subscribers
-  events/               # SAM local invoke payloads
-  test_api.py           # Leads endpoint tests
-  test_locations.py     # Locations endpoint tests
-  test_subscribers.py   # Subscribers + Stripe webhook tests
-template.yaml           # SAM / CloudFormation
-samconfig.toml          # Deploy configuration
-docker-compose.yml      # DynamoDB Local
+  test_api.py
+  test_auth.py
+  test_locations.py
+  test_users.py
+  test_dynamo.py
+  test_scraper.py
+  test_s3.py
+template.yaml             # SAM / CloudFormation
+samconfig.toml            # Deploy configuration
+docker-compose.yml        # DynamoDB Local
 Makefile
 ```


### PR DESCRIPTION
## Summary
- Full rewrite of README to reflect current app state
- Add UI section: pages, libraries, auth flow, local dev instructions, production build
- Update architecture diagram to include CloudFront SPA, auth routes, and admin routes
- Replace `subscribers` with `users` throughout
- Add Auth and Admin API reference sections
- Update Stripe webhook URL to `api.collincountyleads.com`
- Add custom domain / Cloudflare DNS notes and SES sandbox warning
- Update project structure to include `ui/` tree and `parse_document/`

Also includes the previously dropped `deploy.yml` fix (domain params for SAM deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)