### PR TITLE
feat: enrich leads — links, dedup, enrichment, prompt logging

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /Users/steven/Developer/probate-scraper/scripts/extract_session.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .env
-.claude
+.claude/settings.local.json
 .DS_Store
 .aws-sam/
 .vscode/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,18 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Git workflow
 
 - Always push commits to the current branch. Never create a new branch unless explicitly told to.
+- When committing, add a `Prompted-by:` trailer as the last line of the commit message body (before `Co-Authored-By:`). Summarise the user's intent in ≤ 120 characters — what they asked for, not what you did. Example:
+  ```
+  Prompted-by: split the leads table into documents, contacts, and properties
+  ```
+
+## Prompt history
+
+Every Claude session is automatically logged to `docs/sessions/` via the Stop hook in `.claude/settings.json`. Each file captures all user prompts with timestamps for that session.
+
+- Session files are named `YYYY-MM-DD-{short-session-id}.md`
+- When opening a PR, reference the session file in the PR body so reviewers can see what was asked
+- These files are committed alongside code changes to preserve designer intent
 
 ## Commands
 

--- a/docs/sessions/2026-03-07-01c92975.md
+++ b/docs/sessions/2026-03-07-01c92975.md
@@ -1,0 +1,23 @@
+# Session 01c92975
+
+**Date:** 2026-03-07  
+**Branch:** feature/prospect-email  
+**Session ID:** 01c92975-9dcb-4830-a57e-2a522a8b21ea  
+
+_3 prompts_
+
+---
+
+### [1] 2026-03-07 16:40
+
+fatal: mmap failed: Operation timed out
+
+### [2] 2026-03-07 16:52
+
+i  mv probate-scraper _probate-scraper because there are file issues
+then git clone from github to probate-scraper
+recommend which local files in _probate-scraperto copy to probate-scraper
+
+### [3] 2026-03-07 16:54
+
+copy must and recommended

--- a/docs/sessions/2026-03-07-723ead83.md
+++ b/docs/sessions/2026-03-07-723ead83.md
@@ -1,0 +1,22 @@
+# Session 723ead83
+
+**Date:** 2026-03-07  
+**Branch:** main  
+**Session ID:** 723ead83-d8dc-459f-b8a3-ed69d13d43a5  
+
+_3 prompts_
+
+---
+
+### [1] 2026-03-07 17:20
+
+on Desktop there is a folder iCloud Drive (Archive)
+which folders or files are duplicates of iCloud Drive and can be deleted
+
+### [2] 2026-03-07 17:26
+
+yes
+
+### [3] 2026-03-07 17:29
+
+yes

--- a/docs/sessions/2026-03-07-e663b9ea.md
+++ b/docs/sessions/2026-03-07-e663b9ea.md
@@ -1,0 +1,1190 @@
+# Session e663b9ea
+
+**Date:** 2026-03-07  
+**Branch:** feature/prospect-email  
+**Session ID:** e663b9ea-bfdd-4175-afc0-fb9bfc0a8c70  
+
+_73 prompts_
+
+---
+
+### [1] 2026-03-07 18:50
+
+File with same data already exists at probate-scraper-collin-tx/6e64557254379d514db1c75174c57f9d, skipping upload
+
+	Deploying with following values
+	===============================
+	Stack name                   : probate-scraper-collin-tx
+	Region                       : us-east-1
+	Confirm changeset            : False
+	Disable rollback             : False
+	Deployment s3 bucket         : aws-sam-cli-managed-default-samclisourcebucket-szpbe2b7rgun
+	Capabilities                 : ["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"]
+	Parameter overrides          : {"VpcId": "vpc-05ba2b5563a179d60", "SubnetIds": "subnet-066bc56d9cfcca086,subnet-0363963d2a87e1daa,subnet-06f4ff9a91697e9a6,subnet-0d39d5de58fd2a614,subnet-0f486eb14a635b17a,subnet-0af094e4c487f717e", "ScraperImageUri": "600775874112.dkr.ecr.us-east-1.amazonaws.com/probate-scraper/scraper", "JwtSecret": "*****", "MagicLinkBaseUrl": "__https://collincountyleads.com/auth/verify__", "FromEmail": "hello@collincountyleads.com", "AcmCertificateArn": "arn:aws:acm:us-east-1:600775874112:certificate/396a9f34-bb06-4414-97ed-16a71c44129b", "UiDomainAliases": "collincountyleads.com,www.collincountyleads.com", "ApiDomainName": "api.collincountyleads.com", "UiBaseUrl": "__https://collincountyleads.com__", "StripeSecretKey": "*****", "StripeWebhookSecret": "*****", "ScraperUsername": "***", "ScraperPassword": "*****"}
+	Signing Profiles             : {}
+Initiating deployment
+=====================
+	File with same data already exists at probate-scraper-collin-tx/25cd38f7817532de769850cd1b07aee7.template, skipping upload
+Waiting for changeset to be created..
+Error: Failed to create changeset for the stack: probate-scraper-collin-tx, ex: Waiter ChangeSetCreateComplete failed: Waiter encountered a terminal failure state: For expression "Status" we matched expected path: "FAILED" Status: FAILED. Reason: The following hook(s)/validation failed: [AWS::EarlyValidation::ResourceExistenceCheck]. To troubleshoot Early Validation errors, use the DescribeEvents API for detailed failure information.
+Error: Process completed with exit code 1.
+
+### [2] 2026-03-07 19:06
+
+change name from activities to events for table and endpoints and anywhere it appears
+integrate ses event publishing
+add variant
+do not add stats endpoint, we'll do it later
+delete the empty table and create it properly like the others
+
+### [3] 2026-03-07 19:31
+
+change POST /admin/event/log to POST /events
+how is POST /admin/event/log differenf from POST /event/track? can they be combined?
+how does POST /admin/event/query work? can it be a GET with query param?
+
+### [4] 2026-03-07 19:39
+
+change to
+POST /events
+GET /events
+
+### [5] 2026-03-07 19:49
+
+pr
+
+### [6] 2026-03-07 20:09
+
+un # Build overrides array. Stripe params are optional — SAM rejects
+  # Build overrides array. Stripe params are optional — SAM rejects
+# "Key=" (empty value), so only include them when the secret is set.
+# ScrapeSchedule is intentionally omitted — it contains spaces which
+# SAM CLI cannot handle in --parameter-overrides. The template
+# Default "cron(0 6 * * ? *)" is used automatically.
+# JwtSecret is read from SSM in the prior step and masked in logs.
+# MagicLinkBaseUrl/FromEmail: use GHA var if set, else hardcoded default.
+# NOTE: --parameter-overrides on the CLI replaces samconfig.toml ones,
+# so these must always be included explicitly.
+OVERRIDES=(
+  "VpcId=$VPC_ID"
+  "SubnetIds=$SUBNET_IDS"
+  "ScraperImageUri=$ECR_URI"
+  "JwtSecret=***"
+  "MagicLinkBaseUrl=$MAGIC_LINK_BASE_URL"
+  "FromEmail=$FROM_EMAIL"
+  "AcmCertificateArn=arn:aws:acm:us-east-1:600775874112:certificate/396a9f34-bb06-4414-97ed-16a71c44129b"
+  "UiDomainAliases=collincountyleads.com,www.collincountyleads.com"
+  "ApiDomainName=api.collincountyleads.com"
+  "UiBaseUrl=__https://collincountyleads.com__"
+)
+[ -n "$STRIPE_SECRET_KEY" ]    && OVERRIDES+=("StripeSecretKey=$STRIPE_SECRET_KEY")
+[ -n "$STRIPE_WEBHOOK_SECRET" ] && OVERRIDES+=("StripeWebhookSecret=$STRIPE_WEBHOOK_SECRET")
+[ -n "$USERNAME_COLLINTX" ]    && OVERRIDES+=("ScraperUsername=$USERNAME_COLLINTX")
+[ -n "$PASSWORD_COLLINTX" ]    && OVERRIDES+=("ScraperPassword=$PASSWORD_COLLINTX")
+sam deploy \
+  --no-confirm-changeset \
+  --no-fail-on-empty-changeset \
+  --parameter-overrides "${OVERRIDES[@]}"
+shell: /usr/bin/bash -e {0}
+env:
+  AWS_REGION: us-east-1
+  ACCOUNT_ID: 600775874112
+  ECR_REPO: probate-scraper/scraper
+  STACK_NAME: probate-scraper-collin-tx
+  AWS_DEFAULT_REGION: us-east-1
+  AWS_ACCESS_KEY_ID: ***
+  AWS_SECRET_ACCESS_KEY: ***
+  VPC_ID: vpc-05ba2b5563a179d60
+  SUBNET_IDS: subnet-066bc56d9cfcca086,subnet-0363963d2a87e1daa,subnet-06f4ff9a91697e9a6,subnet-0d39d5de58fd2a614,subnet-0f486eb14a635b17a,subnet-0af094e4c487f717e
+  ECR_URI: 600775874112.dkr.ecr.us-east-1.amazonaws.com/probate-scraper/scraper
+  STRIPE_SECRET_KEY: ***
+  STRIPE_WEBHOOK_SECRET: ***
+  USERNAME_COLLINTX: ***
+  PASSWORD_COLLINTX: ***
+  MAGIC_LINK_BASE_URL: __https://collincountyleads.com/auth/verify__
+  FROM_EMAIL: hello@collincountyleads.com
+	Managed S3 bucket: aws-sam-cli-managed-default-samclisourcebucket-szpbe2b7rgun
+	Auto resolution of buckets can be turned off by setting resolve_s3=False
+	To use a specific S3 bucket, set --s3-bucket=<bucket_name>
+	Above settings can be stored in samconfig.toml
+	Uploading to probate-scraper-collin-tx/cc9ef8d7c29fff547cef2436abe530a9  1177 / 1177  (100.00%)
+	Uploading to probate-scraper-collin-tx/e30cfd5447a41672cdeff8aeb6477a85  1048576 / 19109489  (5.49%)
+	Uploading to probate-scraper-collin-tx/e30cfd5447a41672cdeff8aeb6477a85  2097152 / 19109489  (10.97%)
+	Uploading to probate-scraper-collin-tx/e30cfd5447a41672cdeff8aeb6477a85  3145728 / 19109489  (16.46%)
+	Uploading to probate-scraper-collin-tx/e30cfd5447a41672cdeff8aeb6477a85  4194304 / 19109489  (21.95%)
+	Uploading to probate-scraper-collin-tx/e30cfd5447a41672cdeff8aeb6477a85  5242880 / 19109489  (27.44%)
+	Uploading to probate-scraper-collin-tx/e30cfd5447a41672cdeff8aeb6477a85  6291456 / 19109489  (32.92%)
+	Uploading to probate-scraper-collin-tx/e30cfd5447a41672cdeff8aeb6477a85  7340032 / 19109489  (38.41%)
+	Uploading to probate-scraper-collin-tx/e30cfd5447a41672cdeff8aeb6477a85  8388608 / 19109489  (43.90%)
+	Uploading to probate-scraper-collin-tx/e30cfd5447a41672cdeff8aeb6477a85  9437184 / 19109489  (49.38%)
+	Uploading to probate-scraper-collin-tx/e30cfd5447a41672cdeff8aeb6477a85  10485760 / 19109489  (54.87%)
+	Uploading to probate-scraper-collin-tx/e30cfd5447a41672cdeff8aeb6477a85  11534336 / 19109489  (60.36%)
+	Uploading to probate-scraper-collin-tx/e30cfd5447a41672cdeff8aeb6477a85  12582912 / 19109489  (65.85%)
+	Uploading to probate-scraper-collin-tx/e30cfd5447a41672cdeff8aeb6477a85  13631488 / 19109489  (71.33%)
+	Uploading to probate-scraper-collin-tx/e30cfd5447a41672cdeff8aeb6477a85  14680064 / 19109489  (76.82%)
+	Uploading to probate-scraper-collin-tx/e30cfd5447a41672cdeff8aeb6477a85  15728640 / 19109489  (82.31%)
+	Uploading to probate-scraper-collin-tx/e30cfd5447a41672cdeff8aeb6477a85  16777216 / 19109489  (87.80%)
+	Uploading to probate-scraper-collin-tx/e30cfd5447a41672cdeff8aeb6477a85  17825792 / 19109489  (93.28%)
+	Uploading to probate-scraper-collin-tx/e30cfd5447a41672cdeff8aeb6477a85  18874368 / 19109489  (98.77%)
+	Uploading to probate-scraper-collin-tx/e30cfd5447a41672cdeff8aeb6477a85  19109489 / 19109489  (100.00%)
+	File with same data already exists at probate-scraper-collin-tx/15a6a507c8fe1b2b1e796a7ab5b02dbd, skipping upload
+	File with same data already exists at probate-scraper-collin-tx/6e64557254379d514db1c75174c57f9d, skipping upload
+	Deploying with following values
+	===============================
+	Stack name                   : probate-scraper-collin-tx
+	Region                       : us-east-1
+	Confirm changeset            : False
+	Disable rollback             : False
+	Deployment s3 bucket         : aws-sam-cli-managed-default-samclisourcebucket-szpbe2b7rgun
+	Capabilities                 : ["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"]
+	Parameter overrides          : {"VpcId": "vpc-05ba2b5563a179d60", "SubnetIds": "subnet-066bc56d9cfcca086,subnet-0363963d2a87e1daa,subnet-06f4ff9a91697e9a6,subnet-0d39d5de58fd2a614,subnet-0f486eb14a635b17a,subnet-0af094e4c487f717e", "ScraperImageUri": "600775874112.dkr.ecr.us-east-1.amazonaws.com/probate-scraper/scraper", "JwtSecret": "*****", "MagicLinkBaseUrl": "__https://collincountyleads.com/auth/verify__", "FromEmail": "hello@collincountyleads.com", "AcmCertificateArn": "arn:aws:acm:us-east-1:600775874112:certificate/396a9f34-bb06-4414-97ed-16a71c44129b", "UiDomainAliases": "collincountyleads.com,www.collincountyleads.com", "ApiDomainName": "api.collincountyleads.com", "UiBaseUrl": "__https://collincountyleads.com__", "StripeSecretKey": "*****", "StripeWebhookSecret": "*****", "ScraperUsername": "***", "ScraperPassword": "*****"}
+	Signing Profiles             : {}
+Initiating deployment
+=====================
+	Uploading to probate-scraper-collin-tx/664d58edb2a998a0e4cb5e203e2b841f.template  36719 / 36719  (100.00%)
+Waiting for changeset to be created..
+CloudFormation stack changeset
+-------------------------------------------------------------------------------------------------
+Operation                LogicalResourceId        ResourceType             Replacement
+-------------------------------------------------------------------------------------------------
++ Add                    ApiFunctionAdminProspe   AWS::Lambda::Permissio   N/A
+                         ctSendPermissionprod     n
++ Add                    ApiFunctionGetEventsPe   AWS::Lambda::Permissio   N/A
+                         rmissionprod             n
++ Add                    ApiFunctionOptionsAdmi   AWS::Lambda::Permissio   N/A
+                         nProspectSendPermissio   n
+                         nprod
++ Add                    ApiFunctionOptionsEven   AWS::Lambda::Permissio   N/A
+                         tsPermissionprod         n
++ Add                    ApiFunctionPostEventsP   AWS::Lambda::Permissio   N/A
+                         ermissionprod            n
++ Add                    EventsTable              AWS::DynamoDB::Table     N/A
++ Add                    ProbateApiDeploymentc3   AWS::ApiGateway::Deplo   N/A
+                         1962ff83                 yment
++ Add                    SesConfigurationSetEve   AWS::SES::Configuratio   N/A
+                         ntDestination            nSetEventDestination
++ Add                    SesConfigurationSet      AWS::SES::Configuratio   N/A
+                                                  nSet
++ Add                    SesEventsFunctionRole    AWS::IAM::Role           N/A
++ Add                    SesEventsFunctionSnsEv   AWS::Lambda::Permissio   N/A
+                         entPermission            n
++ Add                    SesEventsFunctionSnsEv   AWS::SNS::Subscription   N/A
+                         ent
++ Add                    SesEventsFunction        AWS::Lambda::Function    N/A
++ Add                    SesEventsTopicPolicy     AWS::SNS::TopicPolicy    N/A
++ Add                    SesEventsTopic           AWS::SNS::Topic          N/A
+* Modify                 ApiFunctionRole          AWS::IAM::Role           False
+* Modify                 ApiFunction              AWS::Lambda::Function    False
+* Modify                 ParseDocumentFunction    AWS::Lambda::Function    False
+* Modify                 ProbateApiprodStage      AWS::ApiGateway::Stage   False
+* Modify                 ProbateApi               AWS::ApiGateway::RestA   False
+                                                  pi
+* Modify                 TriggerFunction          AWS::Lambda::Function    False
+- Delete                 ApiFunctionAdminFunnel   AWS::Lambda::Permissio   N/A
+                         SendPermissionprod       n
+- Delete                 ApiFunctionOptionsAdmi   AWS::Lambda::Permissio   N/A
+                         nFunnelSendPermissionp   n
+                         rod
+- Delete                 ProbateApiDeployment87   AWS::ApiGateway::Deplo   N/A
+                         ca50d5bb                 yment
+- Delete                 ProbateApiDeploymentdb   AWS::ApiGateway::Deplo   N/A
+                         e8dc67a1                 yment
+-------------------------------------------------------------------------------------------------
+Changeset created successfully. arn:aws:cloudformation:us-east-1:600775874112:changeSet/samcli-deploy1772931265/16dd1145-eb69-4cd1-89be-a6610c4ee378
+2026-03-08 00:54:47 - Waiting for stack create/update to complete
+CloudFormation events from stack operations (refresh every 5.0 seconds)
+-------------------------------------------------------------------------------------------------
+ResourceStatus           ResourceType             LogicalResourceId        ResourceStatusReason
+-------------------------------------------------------------------------------------------------
+UPDATE_IN_PROGRESS       AWS::CloudFormation::S   probate-scraper-         User Initiated
+                         tack                     collin-tx
+CREATE_IN_PROGRESS       AWS::SES::Configuratio   SesConfigurationSet      -
+                         nSet
+CREATE_IN_PROGRESS       AWS::DynamoDB::Table     EventsTable              -
+CREATE_IN_PROGRESS       AWS::IAM::Role           SesEventsFunctionRole    -
+CREATE_IN_PROGRESS       AWS::SNS::Topic          SesEventsTopic           -
+CREATE_FAILED            AWS::SNS::Topic          SesEventsTopic           Resource handler
+                                                                           returned message:
+                                                                           "User: arn:aws:iam::60
+                                                                           0775874112:user/probat
+                                                                           e-scraper-deploy is
+                                                                           not authorized to
+                                                                           perform:
+                                                                           SNS:GetTopicAttributes
+                                                                           on resource:
+                                                                           arn:aws:sns:us-east-
+                                                                           1:600775874112:probate
+                                                                           -scraper-collin-tx-
+                                                                           ses-events because no
+                                                                           identity-based policy
+                                                                           allows the
+                                                                           SNS:GetTopicAttributes
+                                                                           action (Service: Sns,
+                                                                           Status Code: 403,
+                                                                           Request ID: 074f9d05-
+                                                                           16e7-5c8a-842f-
+                                                                           ff23ddf9db0d) (SDK
+                                                                           Attempt Count: 1)"
+                                                                           (RequestToken: 71434f2
+                                                                           e-cf67-c0b4-3e61-
+                                                                           019ec2d800b5,
+                                                                           HandlerErrorCode:
+                                                                           AccessDenied)
+CREATE_IN_PROGRESS       AWS::IAM::Role           SesEventsFunctionRole    Resource creation
+                                                                           Initiated
+CREATE_FAILED            AWS::SES::Configuratio   SesConfigurationSet      Resource handler
+                         nSet                                              returned message:
+                                                                           "Error occurred during
+                                                                           operation 'User: arn:a
+                                                                           ws:iam::600775874112:u
+                                                                           ser/probate-scraper-
+                                                                           deploy is not
+                                                                           authorized to perform:
+                                                                           ses:CreateConfiguratio
+                                                                           nSet on resource:
+                                                                           arn:aws:ses:us-east-
+                                                                           1:600775874112:configu
+                                                                           ration-set/probate-
+                                                                           scraper-collin-tx-
+                                                                           events because no
+                                                                           identity-based policy
+                                                                           allows the ses:CreateC
+                                                                           onfigurationSet action
+                                                                           (Service: SesV2,
+                                                                           Status Code: 403,
+                                                                           Request ID: d0c6c7ef-
+                                                                           b5b2-4d0b-98da-
+                                                                           579e4057922a) (SDK
+                                                                           Attempt Count: 1)'."
+                                                                           (RequestToken: 6b95fdc
+                                                                           e-f3b3-5e9a-8127-
+                                                                           e4f7af38c5cc,
+                                                                           HandlerErrorCode: Gene
+                                                                           ralServiceException)
+CREATE_FAILED            AWS::IAM::Role           SesEventsFunctionRole    Resource creation
+                                                                           cancelled
+CREATE_FAILED            AWS::DynamoDB::Table     EventsTable              Resource creation
+                                                                           cancelled
+UPDATE_ROLLBACK_IN_PRO   AWS::CloudFormation::S   probate-scraper-         The following
+GRESS                    tack                     collin-tx                resource(s) failed to
+                                                                           create: [EventsTable,
+                                                                           SesEventsFunctionRole,
+                                                                           SesEventsTopic,
+                                                                           SesConfigurationSet].
+UPDATE_ROLLBACK_COMPLE   AWS::CloudFormation::S   probate-scraper-         -
+TE_CLEANUP_IN_PROGRESS   tack                     collin-tx
+DELETE_IN_PROGRESS       AWS::IAM::Role           SesEventsFunctionRole    -
+DELETE_COMPLETE          AWS::SES::Configuratio   SesConfigurationSet      -
+                         nSet
+DELETE_SKIPPED           AWS::DynamoDB::Table     EventsTable              -
+DELETE_COMPLETE          AWS::IAM::Role           SesEventsFunctionRole    -
+DELETE_COMPLETE          AWS::SNS::Topic          SesEventsTopic           -
+UPDATE_ROLLBACK_COMPLE   AWS::CloudFormation::S   probate-scraper-         -
+TE                       tack                     collin-tx
+-------------------------------------------------------------------------------------------------
+Error: Failed to create/update the stack: probate-scraper-collin-tx, Waiter StackUpdateComplete failed: Waiter encountered a terminal failure state: For expression "Stacks[].StackStatus" we matched expected path: "UPDATE_ROLLBACK_COMPLETE" at least once
+Error: Process completed with exit code 1.
+
+### [7] 2026-03-07 21:47
+
+what is the admin email
+
+### [8] 2026-03-07 22:17
+
+new branch
+plan a new feature
+split the leads table into the scraped part with the doc link, call that documents
+we should be careful to limit web clicks and downloads, so the documents table should not be overwritten
+the added parts from parsing and enriching go to two tables, call that contacts and properties
+contacts can be the deceased person, executor, family members, or others mentioned in the document
+properties should be the real estate in the deceased estate
+
+### [9] 2026-03-07 22:20
+
+is the new branch up to date? continue
+
+### [10] 2026-03-08 14:01
+
+resume
+
+### [11] 2026-03-08 23:21
+
+pr
+
+### [12] 2026-03-09 08:22
+
+Smoke tests — __https://ojg08tdrbh.execute-api.us-east-1.amazonaws.com/prod__
+======================================================================
+── Locations ──────────────────────────────────────────────────────────
+✓  GET /locations → 200
+✓  response has 'locations' array
+✓  response has 'count' field
+✓  CollinTx is present
+✓  GET /locations/CollinTx → 200
+✓  locationCode == CollinTx
+✓  locationPath == collin-tx
+✓  locationName is present
+✓  searchUrl is present
+✓  GET /locations/DoesNotExist999 → 404
+── Leads ──────────────────────────────────────────────────────────────
+✗  GET /collin-tx/leads → 200
+HTTP 403: {"message":"Missing Authentication Token"}
+✗  GET /collin-tx/leads?limit=2 → 200
+HTTP 403: {"message":"Missing Authentication Token"}
+✗  GET /no-such-county/leads → 404
+HTTP 403: {"message":"Missing Authentication Token"}
+✗  GET /collin-tx/leads (no dates) → 200
+HTTP 403: {"message":"Missing Authentication Token"}
+── Users ──────────────────────────────────────────────────────────────
+✓  POST /users → 201
+✓  response has userId
+✓  email matches
+✓  status is active
+✓  locationCodes is a list
+✓  POST /users (no email) → 400
+✓  POST /users (bad location) → 422
+✓  GET /users/{id} → 200
+✓  userId matches
+✓  email matches
+✓  PATCH /users/{id} → 200
+✓  status updated to inactive
+✓  PATCH /users/{id} (bad status) → 400
+✓  DELETE /users/{id} → 200
+✓  status set to inactive on delete
+✓  GET /users/nonexistent → 404
+✓  GET /users (no API key) → 403
+── Stripe webhook ─────────────────────────────────────────────────────
+✓  POST /stripe/webhook is reachable (200 or 400)
+── Auth / CORS ─────────────────────────────────────────────────────────
+✓  OPTIONS /auth/request-login (no API key) → 200 or 204
+✓  CORS: access-control-allow-origin present
+✓  CORS: access-control-allow-methods includes POST
+✓  POST /auth/request-login (no API key) → 200
+✓  GET /auth/verify (bad token) → 401
+── UI (__https://d2ujyhjv7lyevl.cloudfront.net__) ────────────────────────────────────────────────────────
+✓  GET / → 200
+✓  Content-Type is text/html
+✓  HTML has <div id="root">
+✓  HTML references a JS bundle
+✓  GET /auth/verify (deep-link) → 200 with HTML
+======================================================================
+FAILED  4/42 checks failed
+======================================================================
+Error: Process completed with exit code 1.
+
+### [13] 2026-03-09 08:37
+
+pr
+
+### [14] 2026-03-09 08:43
+
+new pr
+
+### [15] 2026-03-09 08:45
+
+[Request interrupted by user for tool use]
+
+### [16] 2026-03-09 08:45
+
+use the existing branch
+
+### [17] 2026-03-09 09:40
+
+fix make start-all
+
+### [18] 2026-03-09 09:47
+
+create new branch feature/enrich-leads and make updates there
+
+### [19] 2026-03-09 10:11
+
+ui@0.1.0 dev
+> vite --port 3001
+
+sh: vite: command not found
+
+### [20] 2026-03-09 10:12
+
+[Request interrupted by user for tool use]
+
+### [21] 2026-03-09 10:12
+
+fix
+
+### [22] 2026-03-09 10:15
+
+Failed to send magic link
+
+### [23] 2026-03-09 10:25
+
+run scraper locally
+
+### [24] 2026-03-09 10:45
+
+HTTPError: 404 Client Error: Not Found for url: http://localhost:3000/real-estate/probate-leads/documents/3f2ab7c4-f5d1-5e71-b650-97b7c2ff37d1/parse-document
+
+### [25] 2026-03-09 15:09
+
+write a script that checks the document s3 bucket
+for any file in the bucket
+if the filename matches a docNumber in the documents table on aws
+and docS3Uri is blank
+insert docS3Uri into the record
+write a second script that updates the local db documents table
+
+### [26] 2026-03-09 15:25
+
+use existing s3 bucket
+
+### [27] 2026-03-09 15:51
+
+parsing this document had no results
+{'documentId': '3f2ab7c4-f5d1-5e71-b650-97b7c2ff37d1',  'docNumber': '2026000028265',  'docS3Uri': 's3://probate-scraper-collin-tx-documentsbucket-atqg0aimr8md/documents/CollinTx/2026000028265.pdf',  'parsedAt': '2026-03-09T19:35:11.327257+00:00',  'parseError': '',  'contactsWritten': 0,  'propertiesWritten': 0}
+but i can see in the document
+deceased is Cesare Fred Ciatti
+heir Shannon Pauline Ciatti
+heir Marla Jean Walsh
+heir Brent Joseph Ciatti
+property 301 Dregonfly Drive in Prosper Texas
+
+### [28] 2026-03-09 16:11
+
+update readme
+add a GET /documents/{document_id} endpoint that includes all attributes and child attributes
+add a ui detail page that shows this information
+
+### [29] 2026-03-09 16:29
+
+pr
+
+### [30] 2026-03-09 16:37
+
+readme has some old endpoints with activity and funnel
+
+### [31] 2026-03-09 16:44
+
+pr
+
+### [32] 2026-03-09 16:45
+
+pr 73 is already merged. make a new pr
+
+### [33] 2026-03-09 20:59
+
+https://collincountyleads.com/documents/82bc8ac2-8bfb-5e25-977f-08d3c1334b28 doesn't work, says failed to fetch
+
+### [34] 2026-03-09 21:15
+
+new pr
+
+### [35] 2026-03-10 08:08
+
+add update and delete endpoints and ui forms for contacts and properties
+add email to contacts
+add a field to contacts and properties for the raw response from bedrock and save it there
+strengthen the prompt to pull beneficiaries named in the will
+changer the prompt to omit court personnel like the county clerk
+
+### [36] 2026-03-10 09:38
+
+new pr
+
+### [37] 2026-03-10 10:09
+
+Managed S3 bucket: aws-sam-cli-managed-default-samclisourcebucket-szpbe2b7rgun
+	Auto resolution of buckets can be turned off by setting resolve_s3=False
+	To use a specific S3 bucket, set --s3-bucket=<bucket_name>
+	Above settings can be stored in samconfig.toml
+	File with same data already exists at probate-scraper-collin-tx/cc9ef8d7c29fff547cef2436abe530a9, skipping upload
+	Uploading to probate-scraper-collin-tx/7bd172c3eb871ec0f9c9d4dd7a5347f1  1048576 / 19114459  (5.49%)
+	Uploading to probate-scraper-collin-tx/7bd172c3eb871ec0f9c9d4dd7a5347f1  2097152 / 19114459  (10.97%)
+	Uploading to probate-scraper-collin-tx/7bd172c3eb871ec0f9c9d4dd7a5347f1  3145728 / 19114459  (16.46%)
+	Uploading to probate-scraper-collin-tx/7bd172c3eb871ec0f9c9d4dd7a5347f1  4194304 / 19114459  (21.94%)
+	Uploading to probate-scraper-collin-tx/7bd172c3eb871ec0f9c9d4dd7a5347f1  5242880 / 19114459  (27.43%)
+	Uploading to probate-scraper-collin-tx/7bd172c3eb871ec0f9c9d4dd7a5347f1  6291456 / 19114459  (32.91%)
+	Uploading to probate-scraper-collin-tx/7bd172c3eb871ec0f9c9d4dd7a5347f1  7340032 / 19114459  (38.40%)
+	Uploading to probate-scraper-collin-tx/7bd172c3eb871ec0f9c9d4dd7a5347f1  8388608 / 19114459  (43.89%)
+	Uploading to probate-scraper-collin-tx/7bd172c3eb871ec0f9c9d4dd7a5347f1  9437184 / 19114459  (49.37%)
+	Uploading to probate-scraper-collin-tx/7bd172c3eb871ec0f9c9d4dd7a5347f1  10485760 / 19114459  (54.86%)
+	Uploading to probate-scraper-collin-tx/7bd172c3eb871ec0f9c9d4dd7a5347f1  11534336 / 19114459  (60.34%)
+	Uploading to probate-scraper-collin-tx/7bd172c3eb871ec0f9c9d4dd7a5347f1  12582912 / 19114459  (65.83%)
+	Uploading to probate-scraper-collin-tx/7bd172c3eb871ec0f9c9d4dd7a5347f1  13631488 / 19114459  (71.32%)
+	Uploading to probate-scraper-collin-tx/7bd172c3eb871ec0f9c9d4dd7a5347f1  14680064 / 19114459  (76.80%)
+	Uploading to probate-scraper-collin-tx/7bd172c3eb871ec0f9c9d4dd7a5347f1  15728640 / 19114459  (82.29%)
+	Uploading to probate-scraper-collin-tx/7bd172c3eb871ec0f9c9d4dd7a5347f1  16777216 / 19114459  (87.77%)
+	Uploading to probate-scraper-collin-tx/7bd172c3eb871ec0f9c9d4dd7a5347f1  17825792 / 19114459  (93.26%)
+	Uploading to probate-scraper-collin-tx/7bd172c3eb871ec0f9c9d4dd7a5347f1  18874368 / 19114459  (98.74%)
+	Uploading to probate-scraper-collin-tx/7bd172c3eb871ec0f9c9d4dd7a5347f1  19114459 / 19114459  (100.00%)
+	File with same data already exists at probate-scraper-collin-tx/1ee706e7e219781334068eb6018b4eb6, skipping upload
+	Uploading to probate-scraper-collin-tx/d03476c021047a5e9012979d77c838f7  1048576 / 16229111  (6.46%)
+	Uploading to probate-scraper-collin-tx/d03476c021047a5e9012979d77c838f7  2097152 / 16229111  (12.92%)
+	Uploading to probate-scraper-collin-tx/d03476c021047a5e9012979d77c838f7  3145728 / 16229111  (19.38%)
+	Uploading to probate-scraper-collin-tx/d03476c021047a5e9012979d77c838f7  4194304 / 16229111  (25.84%)
+	Uploading to probate-scraper-collin-tx/d03476c021047a5e9012979d77c838f7  5242880 / 16229111  (32.31%)
+	Uploading to probate-scraper-collin-tx/d03476c021047a5e9012979d77c838f7  6291456 / 16229111  (38.77%)
+	Uploading to probate-scraper-collin-tx/d03476c021047a5e9012979d77c838f7  7340032 / 16229111  (45.23%)
+	Uploading to probate-scraper-collin-tx/d03476c021047a5e9012979d77c838f7  8388608 / 16229111  (51.69%)
+	Uploading to probate-scraper-collin-tx/d03476c021047a5e9012979d77c838f7  9437184 / 16229111  (58.15%)
+	Uploading to probate-scraper-collin-tx/d03476c021047a5e9012979d77c838f7  10485760 / 16229111  (64.61%)
+	Uploading to probate-scraper-collin-tx/d03476c021047a5e9012979d77c838f7  11534336 / 16229111  (71.07%)
+	Uploading to probate-scraper-collin-tx/d03476c021047a5e9012979d77c838f7  12034807 / 16229111  (74.16%)
+	Uploading to probate-scraper-collin-tx/d03476c021047a5e9012979d77c838f7  13083383 / 16229111  (80.62%)
+	Uploading to probate-scraper-collin-tx/d03476c021047a5e9012979d77c838f7  14131959 / 16229111  (87.08%)
+	Uploading to probate-scraper-collin-tx/d03476c021047a5e9012979d77c838f7  15180535 / 16229111  (93.54%)
+	Uploading to probate-scraper-collin-tx/d03476c021047a5e9012979d77c838f7  16229111 / 16229111  (100.00%)
+	Deploying with following values
+	===============================
+	Stack name                   : probate-scraper-collin-tx
+	Region                       : us-east-1
+	Confirm changeset            : False
+	Disable rollback             : False
+	Deployment s3 bucket         : aws-sam-cli-managed-default-samclisourcebucket-szpbe2b7rgun
+	Capabilities                 : ["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"]
+	Parameter overrides          : {"VpcId": "vpc-05ba2b5563a179d60", "SubnetIds": "subnet-066bc56d9cfcca086,subnet-0363963d2a87e1daa,subnet-06f4ff9a91697e9a6,subnet-0d39d5de58fd2a614,subnet-0f486eb14a635b17a,subnet-0af094e4c487f717e", "ScraperImageUri": "600775874112.dkr.ecr.us-east-1.amazonaws.com/probate-scraper/scraper", "JwtSecret": "*****", "MagicLinkBaseUrl": "__https://collincountyleads.com/auth/verify__", "FromEmail": "hello@collincountyleads.com", "AcmCertificateArn": "arn:aws:acm:us-east-1:600775874112:certificate/396a9f34-bb06-4414-97ed-16a71c44129b", "UiDomainAliases": "collincountyleads.com,www.collincountyleads.com", "ApiDomainName": "api.collincountyleads.com", "UiBaseUrl": "__https://collincountyleads.com__", "StripeSecretKey": "*****", "StripeWebhookSecret": "*****", "ScraperUsername": "***", "ScraperPassword": "*****"}
+	Signing Profiles             : {}
+Initiating deployment
+=====================
+	Uploading to probate-scraper-collin-tx/901ce5c98d6160ec5977b1407b117ec1.template  42649 / 42649  (100.00%)
+Waiting for changeset to be created..
+CloudFormation stack changeset
+-------------------------------------------------------------------------------------------------
+Operation                LogicalResourceId        ResourceType             Replacement
+-------------------------------------------------------------------------------------------------
++ Add                    ApiFunctionDeleteConta   AWS::Lambda::Permissio   N/A
+                         ctPermissionprod         n
++ Add                    ApiFunctionDeletePrope   AWS::Lambda::Permissio   N/A
+                         rtyPermissionprod        n
++ Add                    ApiFunctionOptionsCont   AWS::Lambda::Permissio   N/A
+                         actPermissionprod        n
++ Add                    ApiFunctionOptionsProp   AWS::Lambda::Permissio   N/A
+                         ertyPermissionprod       n
++ Add                    ApiFunctionUpdateConta   AWS::Lambda::Permissio   N/A
+                         ctPermissionprod         n
++ Add                    ApiFunctionUpdatePrope   AWS::Lambda::Permissio   N/A
+                         rtyPermissionprod        n
++ Add                    ProbateApiDeployment89   AWS::ApiGateway::Deplo   N/A
+                         89f475e5                 yment
+* Modify                 ApiFunction              AWS::Lambda::Function    False
+* Modify                 ParseDocumentFunction    AWS::Lambda::Function    False
+* Modify                 ProbateApiprodStage      AWS::ApiGateway::Stage   False
+* Modify                 ProbateApi               AWS::ApiGateway::RestA   False
+                                                  pi
+- Delete                 ProbateApiDeployment7f   AWS::ApiGateway::Deplo   N/A
+                         465b284a                 yment
+-------------------------------------------------------------------------------------------------
+Changeset created successfully. arn:aws:cloudformation:us-east-1:600775874112:changeSet/samcli-deploy1773150122/4e94b8a3-95f0-43e1-ab5b-895e02963204
+2026-03-10 13:42:29 - Waiting for stack create/update to complete
+CloudFormation events from stack operations (refresh every 5.0 seconds)
+-------------------------------------------------------------------------------------------------
+ResourceStatus           ResourceType             LogicalResourceId        ResourceStatusReason
+-------------------------------------------------------------------------------------------------
+UPDATE_IN_PROGRESS       AWS::CloudFormation::S   probate-scraper-         User Initiated
+                         tack                     collin-tx
+UPDATE_IN_PROGRESS       AWS::Lambda::Function    ParseDocumentFunction    -
+UPDATE_IN_PROGRESS       AWS::Lambda::Function    ApiFunction              -
+UPDATE_COMPLETE          AWS::Lambda::Function    ParseDocumentFunction    -
+UPDATE_COMPLETE          AWS::Lambda::Function    ApiFunction              -
+UPDATE_IN_PROGRESS       AWS::ApiGateway::RestA   ProbateApi               -
+                         pi
+UPDATE_COMPLETE          AWS::ApiGateway::RestA   ProbateApi               -
+                         pi
+CREATE_IN_PROGRESS       AWS::Lambda::Permissio   ApiFunctionUpdateConta   -
+                         n                        ctPermissionprod
+CREATE_IN_PROGRESS       AWS::Lambda::Permissio   ApiFunctionUpdatePrope   -
+                         n                        rtyPermissionprod
+CREATE_IN_PROGRESS       AWS::ApiGateway::Deplo   ProbateApiDeployment89   -
+                         yment                    89f475e5
+CREATE_IN_PROGRESS       AWS::Lambda::Permissio   ApiFunctionDeleteConta   -
+                         n                        ctPermissionprod
+CREATE_IN_PROGRESS       AWS::Lambda::Permissio   ApiFunctionOptionsProp   -
+                         n                        ertyPermissionprod
+CREATE_IN_PROGRESS       AWS::Lambda::Permissio   ApiFunctionDeletePrope   -
+                         n                        rtyPermissionprod
+CREATE_IN_PROGRESS       AWS::Lambda::Permissio   ApiFunctionOptionsCont   -
+                         n                        actPermissionprod
+CREATE_IN_PROGRESS       AWS::Lambda::Permissio   ApiFunctionUpdateConta   Resource creation
+                         n                        ctPermissionprod         Initiated
+CREATE_IN_PROGRESS       AWS::Lambda::Permissio   ApiFunctionDeletePrope   Resource creation
+                         n                        rtyPermissionprod        Initiated
+CREATE_IN_PROGRESS       AWS::Lambda::Permissio   ApiFunctionDeleteConta   Resource creation
+                         n                        ctPermissionprod         Initiated
+CREATE_IN_PROGRESS       AWS::Lambda::Permissio   ApiFunctionUpdatePrope   Resource creation
+                         n                        rtyPermissionprod        Initiated
+CREATE_IN_PROGRESS       AWS::Lambda::Permissio   ApiFunctionOptionsCont   Resource creation
+                         n                        actPermissionprod        Initiated
+CREATE_IN_PROGRESS       AWS::Lambda::Permissio   ApiFunctionOptionsProp   Resource creation
+                         n                        ertyPermissionprod       Initiated
+CREATE_FAILED            AWS::Lambda::Permissio   ApiFunctionUpdatePrope   Resource handler
+                         n                        rtyPermissionprod        returned message: "The
+                                                                           final policy size
+                                                                           (20610) is bigger than
+                                                                           the limit (20480).
+                                                                           (Service: Lambda,
+                                                                           Status Code: 400,
+                                                                           Request ID: 6df4fb45-
+                                                                           8502-4e20-9da2-
+                                                                           45c128dcf26e) (SDK
+                                                                           Attempt Count: 1)"
+                                                                           (RequestToken: f64822e
+                                                                           1-553f-ac2f-0fe6-
+                                                                           03f6354c0580,
+                                                                           HandlerErrorCode:
+                                                                           InvalidRequest)
+CREATE_FAILED            AWS::Lambda::Permissio   ApiFunctionOptionsCont   Resource handler
+                         n                        actPermissionprod        returned message: "The
+                                                                           final policy size
+                                                                           (20610) is bigger than
+                                                                           the limit (20480).
+                                                                           (Service: Lambda,
+                                                                           Status Code: 400,
+                                                                           Request ID: eae1915a-
+                                                                           05f1-496f-abc0-
+                                                                           002b17616a4c) (SDK
+                                                                           Attempt Count: 1)"
+                                                                           (RequestToken: bb0682b
+                                                                           5-546d-c7e8-9ee8-
+                                                                           1cbea6b18359,
+                                                                           HandlerErrorCode:
+                                                                           InvalidRequest)
+CREATE_COMPLETE          AWS::Lambda::Permissio   ApiFunctionUpdateConta   -
+                         n                        ctPermissionprod
+CREATE_FAILED            AWS::Lambda::Permissio   ApiFunctionOptionsProp   Resource handler
+                         n                        ertyPermissionprod       returned message: "The
+                                                                           final policy size
+                                                                           (20613) is bigger than
+                                                                           the limit (20480).
+                                                                           (Service: Lambda,
+                                                                           Status Code: 400,
+                                                                           Request ID: 67656c57-
+                                                                           337d-4327-8339-
+                                                                           a51f94207803) (SDK
+                                                                           Attempt Count: 1)"
+                                                                           (RequestToken: 2f506db
+                                                                           4-d467-3802-62bc-
+                                                                           89fd248c2a73,
+                                                                           HandlerErrorCode:
+                                                                           InvalidRequest)
+CREATE_IN_PROGRESS       AWS::ApiGateway::Deplo   ProbateApiDeployment89   Resource creation
+                         yment                    89f475e5                 Initiated
+CREATE_FAILED            AWS::Lambda::Permissio   ApiFunctionDeletePrope   Resource creation
+                         n                        rtyPermissionprod        cancelled
+CREATE_FAILED            AWS::Lambda::Permissio   ApiFunctionDeleteConta   Resource creation
+                         n                        ctPermissionprod         cancelled
+CREATE_FAILED            AWS::ApiGateway::Deplo   ProbateApiDeployment89   Resource creation
+                         yment                    89f475e5                 cancelled
+UPDATE_ROLLBACK_IN_PRO   AWS::CloudFormation::S   probate-scraper-         The following
+GRESS                    tack                     collin-tx                resource(s) failed to
+                                                                           create: [ProbateApiDep
+                                                                           loyment8989f475e5, Api
+                                                                           FunctionDeleteContactP
+                                                                           ermissionprod, ApiFunc
+                                                                           tionUpdatePropertyPerm
+                                                                           issionprod, ApiFunctio
+                                                                           nOptionsPropertyPermis
+                                                                           sionprod, ApiFunctionO
+                                                                           ptionsContactPermissio
+                                                                           nprod, ApiFunctionDele
+                                                                           tePropertyPermissionpr
+                                                                           od].
+UPDATE_IN_PROGRESS       AWS::Lambda::Function    ParseDocumentFunction    -
+UPDATE_IN_PROGRESS       AWS::Lambda::Function    ApiFunction              -
+UPDATE_COMPLETE          AWS::Lambda::Function    ParseDocumentFunction    -
+UPDATE_COMPLETE          AWS::Lambda::Function    ApiFunction              -
+UPDATE_IN_PROGRESS       AWS::ApiGateway::RestA   ProbateApi               -
+                         pi
+UPDATE_COMPLETE          AWS::ApiGateway::RestA   ProbateApi               -
+                         pi
+UPDATE_ROLLBACK_COMPLE   AWS::CloudFormation::S   probate-scraper-         -
+TE_CLEANUP_IN_PROGRESS   tack                     collin-tx
+DELETE_IN_PROGRESS       AWS::Lambda::Permissio   ApiFunctionOptionsProp   -
+                         n                        ertyPermissionprod
+DELETE_IN_PROGRESS       AWS::Lambda::Permissio   ApiFunctionDeletePrope   -
+                         n                        rtyPermissionprod
+DELETE_IN_PROGRESS       AWS::Lambda::Permissio   ApiFunctionUpdatePrope   -
+                         n                        rtyPermissionprod
+DELETE_IN_PROGRESS       AWS::Lambda::Permissio   ApiFunctionDeleteConta   -
+                         n                        ctPermissionprod
+DELETE_IN_PROGRESS       AWS::Lambda::Permissio   ApiFunctionUpdateConta   -
+                         n                        ctPermissionprod
+DELETE_IN_PROGRESS       AWS::ApiGateway::Deplo   ProbateApiDeployment89   -
+                         yment                    89f475e5
+DELETE_IN_PROGRESS       AWS::Lambda::Permissio   ApiFunctionOptionsCont   -
+                         n                        actPermissionprod
+DELETE_COMPLETE          AWS::ApiGateway::Deplo   ProbateApiDeployment89   -
+                         yment                    89f475e5
+DELETE_COMPLETE          AWS::Lambda::Permissio   ApiFunctionDeleteConta   -
+                         n                        ctPermissionprod
+DELETE_COMPLETE          AWS::Lambda::Permissio   ApiFunctionUpdatePrope   -
+                         n                        rtyPermissionprod
+DELETE_COMPLETE          AWS::Lambda::Permissio   ApiFunctionOptionsProp   -
+                         n                        ertyPermissionprod
+DELETE_COMPLETE          AWS::Lambda::Permissio   ApiFunctionOptionsCont   -
+                         n                        actPermissionprod
+DELETE_COMPLETE          AWS::Lambda::Permissio   ApiFunctionUpdateConta   -
+                         n                        ctPermissionprod
+DELETE_COMPLETE          AWS::Lambda::Permissio   ApiFunctionDeletePrope   -
+                         n                        rtyPermissionprod
+UPDATE_ROLLBACK_COMPLE   AWS::CloudFormation::S   probate-scraper-         -
+TE                       tack                     collin-tx
+-------------------------------------------------------------------------------------------------
+Error: Failed to create/update the stack: probate-scraper-collin-tx, Waiter StackUpdateComplete failed: Waiter encountered a terminal failure state: For expression "Stacks[].StackStatus" we matched expected path: "UPDATE_ROLLBACK_COMPLETE" at least once
+Error: Process completed with exit code 1.
+
+### [38] 2026-03-10 10:39
+
+Managed S3 bucket: aws-sam-cli-managed-default-samclisourcebucket-szpbe2b7rgun
+	Auto resolution of buckets can be turned off by setting resolve_s3=False
+	To use a specific S3 bucket, set --s3-bucket=<bucket_name>
+	Above settings can be stored in samconfig.toml
+	File with same data already exists at probate-scraper-collin-tx/cc9ef8d7c29fff547cef2436abe530a9, skipping upload
+	File with same data already exists at probate-scraper-collin-tx/7bd172c3eb871ec0f9c9d4dd7a5347f1, skipping upload
+	File with same data already exists at probate-scraper-collin-tx/1ee706e7e219781334068eb6018b4eb6, skipping upload
+	File with same data already exists at probate-scraper-collin-tx/d03476c021047a5e9012979d77c838f7, skipping upload
+	Deploying with following values
+	===============================
+	Stack name                   : probate-scraper-collin-tx
+	Region                       : us-east-1
+	Confirm changeset            : False
+	Disable rollback             : False
+	Deployment s3 bucket         : aws-sam-cli-managed-default-samclisourcebucket-szpbe2b7rgun
+	Capabilities                 : ["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"]
+	Parameter overrides          : {"VpcId": "vpc-05ba2b5563a179d60", "SubnetIds": "subnet-066bc56d9cfcca086,subnet-0363963d2a87e1daa,subnet-06f4ff9a91697e9a6,subnet-0d39d5de58fd2a614,subnet-0f486eb14a635b17a,subnet-0af094e4c487f717e", "ScraperImageUri": "600775874112.dkr.ecr.us-east-1.amazonaws.com/probate-scraper/scraper", "JwtSecret": "*****", "MagicLinkBaseUrl": "__https://collincountyleads.com/auth/verify__", "FromEmail": "hello@collincountyleads.com", "AcmCertificateArn": "arn:aws:acm:us-east-1:600775874112:certificate/396a9f34-bb06-4414-97ed-16a71c44129b", "UiDomainAliases": "collincountyleads.com,www.collincountyleads.com", "ApiDomainName": "api.collincountyleads.com", "UiBaseUrl": "__https://collincountyleads.com__", "StripeSecretKey": "*****", "StripeWebhookSecret": "*****", "ScraperUsername": "***", "ScraperPassword": "*****"}
+	Signing Profiles             : {}
+Initiating deployment
+=====================
+	Uploading to probate-scraper-collin-tx/72378ac659cf9d6885cd3d889eaf9661.template  37171 / 37171  (100.00%)
+Waiting for changeset to be created..
+CloudFormation stack changeset
+-------------------------------------------------------------------------------------------------
+Operation                LogicalResourceId        ResourceType             Replacement
+-------------------------------------------------------------------------------------------------
++ Add                    ApiFunctionDeleteConta   AWS::Lambda::Permissio   N/A
+                         ctPermissionprod         n
++ Add                    ApiFunctionDeletePrope   AWS::Lambda::Permissio   N/A
+                         rtyPermissionprod        n
++ Add                    ApiFunctionUpdateConta   AWS::Lambda::Permissio   N/A
+                         ctPermissionprod         n
++ Add                    ApiFunctionUpdatePrope   AWS::Lambda::Permissio   N/A
+                         rtyPermissionprod        n
++ Add                    ProbateApiDeploymentef   AWS::ApiGateway::Deplo   N/A
+                         c1fd50fb                 yment
+* Modify                 ApiFunction              AWS::Lambda::Function    False
+* Modify                 ParseDocumentFunction    AWS::Lambda::Function    False
+                         n                        rtyPermissionprod
+DELETE_COMPLETE          AWS::Lambda::Permissio   ApiFunctionUpdatePrope   -
+                         n                        rtyPermissionprod
+UPDATE_ROLLBACK_COMPLE   AWS::CloudFormation::S   probate-scraper-         -
+TE                       tack                     collin-tx
+-------------------------------------------------------------------------------------------------
+Error: Failed to create/update the stack: probate-scraper-collin-tx, Waiter StackUpdateComplete failed: Waiter encountered a terminal failure state: For expression "Stacks[].StackStatus" we matched expected path: "UPDATE_ROLLBACK_COMPLETE" at least once
+Error: Process completed with exit code 1.
+
+### [39] 2026-03-10 10:46
+
+[Request interrupted by user for tool use]
+
+### [40] 2026-03-10 10:46
+
+pause
+
+### [41] 2026-03-10 10:47
+
+remove the stack. then i'll run the install again
+
+### [42] 2026-03-10 10:56
+
+delete the second bucket
+rename the first with 'backup' so we can get the document files later
+
+### [43] 2026-03-10 12:58
+
+ready
+
+### [44] 2026-03-10 13:02
+
+don't put mutations into a new lambda. that shouldn't be needed now that stack is gone
+
+### [45] 2026-03-10 13:07
+
+new pr so github will run it
+
+### [46] 2026-03-10 13:14
+
+stack name still has collin-tx and failed
+Managed S3 bucket: aws-sam-cli-managed-default-samclisourcebucket-szpbe2b7rgun
+	Auto resolution of buckets can be turned off by setting resolve_s3=False
+	To use a specific S3 bucket, set --s3-bucket=<bucket_name>
+	Above settings can be stored in samconfig.toml
+	File with same data already exists at probate-scraper-collin-tx/cc9ef8d7c29fff547cef2436abe530a9, skipping upload
+	Uploading to probate-scraper-collin-tx/83da7e92e6f41b2ef4558f5e0be713f0  1048576 / 19114313  (5.49%)
+	Uploading to probate-scraper-collin-tx/83da7e92e6f41b2ef4558f5e0be713f0  2097152 / 19114313  (10.97%)
+	Uploading to probate-scraper-collin-tx/83da7e92e6f41b2ef4558f5e0be713f0  3145728 / 19114313  (16.46%)
+	Uploading to probate-scraper-collin-tx/83da7e92e6f41b2ef4558f5e0be713f0  4194304 / 19114313  (21.94%)
+	Uploading to probate-scraper-collin-tx/83da7e92e6f41b2ef4558f5e0be713f0  5242880 / 19114313  (27.43%)
+	Uploading to probate-scraper-collin-tx/83da7e92e6f41b2ef4558f5e0be713f0  6291456 / 19114313  (32.91%)
+	Uploading to probate-scraper-collin-tx/83da7e92e6f41b2ef4558f5e0be713f0  7340032 / 19114313  (38.40%)
+	Uploading to probate-scraper-collin-tx/83da7e92e6f41b2ef4558f5e0be713f0  8388608 / 19114313  (43.89%)
+	Uploading to probate-scraper-collin-tx/83da7e92e6f41b2ef4558f5e0be713f0  9437184 / 19114313  (49.37%)
+	Uploading to probate-scraper-collin-tx/83da7e92e6f41b2ef4558f5e0be713f0  10485760 / 19114313  (54.86%)
+	Uploading to probate-scraper-collin-tx/83da7e92e6f41b2ef4558f5e0be713f0  11534336 / 19114313  (60.34%)
+	Uploading to probate-scraper-collin-tx/83da7e92e6f41b2ef4558f5e0be713f0  12582912 / 19114313  (65.83%)
+	Uploading to probate-scraper-collin-tx/83da7e92e6f41b2ef4558f5e0be713f0  13631488 / 19114313  (71.32%)
+	Uploading to probate-scraper-collin-tx/83da7e92e6f41b2ef4558f5e0be713f0  14680064 / 19114313  (76.80%)
+	Uploading to probate-scraper-collin-tx/83da7e92e6f41b2ef4558f5e0be713f0  15728640 / 19114313  (82.29%)
+	Uploading to probate-scraper-collin-tx/83da7e92e6f41b2ef4558f5e0be713f0  16777216 / 19114313  (87.77%)
+	Uploading to probate-scraper-collin-tx/83da7e92e6f41b2ef4558f5e0be713f0  17017161 / 19114313  (89.03%)
+	Uploading to probate-scraper-collin-tx/83da7e92e6f41b2ef4558f5e0be713f0  18065737 / 19114313  (94.51%)
+	Uploading to probate-scraper-collin-tx/83da7e92e6f41b2ef4558f5e0be713f0  19114313 / 19114313  (100.00%)
+	File with same data already exists at probate-scraper-collin-tx/1ee706e7e219781334068eb6018b4eb6, skipping upload
+	File with same data already exists at probate-scraper-collin-tx/d03476c021047a5e9012979d77c838f7, skipping upload
+	Deploying with following values
+	===============================
+	Stack name                   : probate-scraper-collin-tx
+	Region                       : us-east-1
+	Confirm changeset            : False
+	Disable rollback             : False
+	Deployment s3 bucket         : aws-sam-cli-managed-default-samclisourcebucket-szpbe2b7rgun
+	Capabilities                 : ["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"]
+	Parameter overrides          : {"VpcId": "vpc-05ba2b5563a179d60", "SubnetIds": "subnet-066bc56d9cfcca086,subnet-0363963d2a87e1daa,subnet-06f4ff9a91697e9a6,subnet-0d39d5de58fd2a614,subnet-0f486eb14a635b17a,subnet-0af094e4c487f717e", "ScraperImageUri": "600775874112.dkr.ecr.us-east-1.amazonaws.com/probate-scraper/scraper", "JwtSecret": "*****", "MagicLinkBaseUrl": "__https://collincountyleads.com/auth/verify__", "FromEmail": "hello@collincountyleads.com", "AcmCertificateArn": "arn:aws:acm:us-east-1:600775874112:certificate/396a9f34-bb06-4414-97ed-16a71c44129b", "UiDomainAliases": "collincountyleads.com,www.collincountyleads.com", "ApiDomainName": "api.collincountyleads.com", "UiBaseUrl": "__https://collincountyleads.com__", "StripeSecretKey": "*****", "StripeWebhookSecret": "*****", "ScraperUsername": "***", "ScraperPassword": "*****"}
+	Signing Profiles             : {}
+Initiating deployment
+=====================
+	Uploading to probate-scraper-collin-tx/93f49fa7b474c4b6c3d70a893153f4d7.template  37171 / 37171  (100.00%)
+Waiting for changeset to be created..
+Error: Failed to create changeset for the stack: probate-scraper-collin-tx, ex: Waiter ChangeSetCreateComplete failed: Waiter encountered a terminal failure state: For expression "Status" we matched expected path: "FAILED" Status: FAILED. Reason: The following hook(s)/validation failed: [AWS::EarlyValidation::ResourceExistenceCheck]. To troubleshoot Early Validation errors, use the DescribeEvents API for detailed failure information.
+Error: Process completed with exit code 1.
+
+### [47] 2026-03-10 13:20
+
+new pr, 83 is already merged
+
+### [48] 2026-03-10 13:28
+
+Run # Build overrides array. Stripe params are optional — SAM rejects
+Usage: sam deploy [OPTIONS]
+Try 'sam deploy -h' for help.
+Error: No such option: --import-existing-resources
+Error: Process completed with exit code 2.
+
+### [49] 2026-03-10 13:37
+
+[Request interrupted by user for tool use]
+
+### [50] 2026-03-10 13:37
+
+pause
+
+### [51] 2026-03-10 13:37
+
+the tables can be deleted and data lost
+
+### [52] 2026-03-10 13:42
+
+when deploy runs again will it destroy the tables? or just this time
+
+### [53] 2026-03-10 13:49
+
+delete arn:aws:s3:::aws-sam-cli-managed-default-samclisourcebucket-szpbe2b7rgun
+
+### [54] 2026-03-10 13:51
+
+[Request interrupted by user for tool use]
+
+### [55] 2026-03-10 14:01
+
+stack name is still probate-scraper-collin-tx
+
+### [56] 2026-03-10 14:06
+
+yes
+
+### [57] 2026-03-10 14:11
+
+when you make a pr i always merge it
+so make a new one when there's work to deploy
+
+### [58] 2026-03-10 14:21
+
+CREATE_COMPLETE          AWS::ECS::Cluster        ScraperCluster           -
+CREATE_FAILED            AWS::ApiGateway::Domai   ApiCustomDomain          Resource handler
+                         nName                                             returned message:
+                                                                           "Invalid request
+                                                                           provided: One or more
+                                                                           aliases specified for
+                                                                           the distribution
+                                                                           includes an
+                                                                           incorrectly configured
+                                                                           DNS record that points
+                                                                           to another CloudFront
+                                                                           distribution. You must
+                                                                           update the DNS record
+                                                                           to correct the
+                                                                           problem. For more
+                                                                           information, see https
+                                                                           ://docs.aws.amazon.com
+                                                                           /AmazonCloudFront/late
+                                                                           st/DeveloperGuide/CNAM
+                                                                           Es.html#alternate-
+                                                                           domain-names-
+                                                                           restrictions (Service:
+                                                                           AmazonCloudFront;
+                                                                           Status Code: 409;
+                                                                           Error Code:
+                                                                           CNAMEAlreadyExists;
+                                                                           Request ID: 974ec905-
+                                                                           8695-440d-8204-
+                                                                           d35bea1c4d99; Proxy:
+                                                                           null) (Service:
+                                                                           ApiGateway, Status
+                                                                           Code: 400, Request ID:
+                                                                           02fa84a0-b225-46dc-
+                                                                           ad4b-7dc7f868a1a1)
+                                                                           (SDK Attempt Count:
+                                                                           1)" (RequestToken: 96a
+                                                                           64c84-27c8-549f-bbbd-
+                                                                           9f1f23b76d12,
+                                                                           HandlerErrorCode:
+                                                                           InvalidRequest)
+CREATE_FAILED            AWS::Logs::LogGroup      ScraperLogGroup          Resource creation
+
+### [59] 2026-03-10 14:49
+
+Deploying with following values
+	===============================
+	Stack name                   : probate-scraper
+	Region                       : us-east-1
+	Confirm changeset            : False
+	Disable rollback             : False
+	Deployment s3 bucket         : aws-sam-cli-managed-default-samclisourcebucket-szpbe2b7rgun
+	Capabilities                 : ["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"]
+	Parameter overrides          : {"VpcId": "vpc-05ba2b5563a179d60", "SubnetIds": "subnet-066bc56d9cfcca086,subnet-0363963d2a87e1daa,subnet-06f4ff9a91697e9a6,subnet-0d39d5de58fd2a614,subnet-0f486eb14a635b17a,subnet-0af094e4c487f717e", "ScraperImageUri": "600775874112.dkr.ecr.us-east-1.amazonaws.com/probate-scraper/scraper", "JwtSecret": "*****", "MagicLinkBaseUrl": "__https://collincountyleads.com/auth/verify__", "FromEmail": "hello@collincountyleads.com", "AcmCertificateArn": "arn:aws:acm:us-east-1:600775874112:certificate/396a9f34-bb06-4414-97ed-16a71c44129b", "UiDomainAliases": "collincountyleads.com,www.collincountyleads.com", "ApiDomainName": "api.collincountyleads.com", "UiBaseUrl": "__https://collincountyleads.com__", "StripeSecretKey": "*****", "StripeWebhookSecret": "*****", "ScraperUsername": "***", "ScraperPassword": "*****"}
+	Signing Profiles             : {}
+Initiating deployment
+=====================
+	File with same data already exists at probate-scraper/d49f3ff89174e19544ac9a101848a0c6.template, skipping upload
+Error: Failed to create changeset for the stack: probate-scraper, An error occurred (ValidationError) when calling the CreateChangeSet operation: Stack:arn:aws:cloudformation:us-east-1:600775874112:stack/probate-scraper/67050c20-1cad-11f1-9e60-12999b134f5f is in ROLLBACK_COMPLETE state and can not be updated.
+Error: Process completed with exit code 1.
+
+### [60] 2026-03-10 15:13
+
+Smoke tests — __https://91x4s2av9d.execute-api.us-east-1.amazonaws.com/prod__
+======================================================================
+── Locations ──────────────────────────────────────────────────────────
+✓  GET /locations → 200
+✓  response has 'locations' array
+✓  response has 'count' field
+✓  CollinTx is present
+✓  GET /locations/CollinTx → 200
+✓  locationCode == CollinTx
+✓  locationPath == collin-tx
+✓  locationName is present
+✓  searchUrl is present
+✓  GET /locations/DoesNotExist999 → 404
+── Documents ──────────────────────────────────────────────────────────
+✓  GET /collin-tx/documents → 200
+✓  response has 'documents' array
+✓  response has 'location' object
+✓  response has 'count' field
+✓  response has 'query' field
+✓  GET /collin-tx/documents?limit=2 → 200
+✓  at most 2 documents returned
+✓  GET /no-such-county/documents → 404
+✓  GET /collin-tx/documents (no dates) → 200
+✓  no-date response has 'documents' array
+── Users ──────────────────────────────────────────────────────────────
+✓  POST /users → 201
+✓  response has userId
+✓  email matches
+✓  status is active
+✓  locationCodes is a list
+✓  POST /users (no email) → 400
+✓  POST /users (bad location) → 422
+✓  GET /users/{id} → 200
+✓  userId matches
+✓  email matches
+✓  PATCH /users/{id} → 200
+✓  status updated to inactive
+✓  PATCH /users/{id} (bad status) → 400
+✓  DELETE /users/{id} → 200
+✓  status set to inactive on delete
+✓  GET /users/nonexistent → 404
+✓  GET /users (no API key) → 403
+── Stripe webhook ─────────────────────────────────────────────────────
+✓  POST /stripe/webhook is reachable (200 or 400)
+── Auth / CORS ─────────────────────────────────────────────────────────
+✗  OPTIONS /auth/request-login (no API key) → 200 or 204
+HTTP 403: {"message":"Forbidden"}
+✓  POST /auth/request-login (no API key) → 200
+✓  GET /auth/verify (bad token) → 401
+── UI (__https://d1q058olyycpul.cloudfront.net__) ────────────────────────────────────────────────────────
+✗  GET / → 200
+HTTP 403: <?xml version="1.0" encoding="UTF-8"?>
+<Error><Code>AccessDenied</Code><Message>Access Denied</Message></Error>
+✗  GET /auth/verify (deep-link) → 200 with HTML
+HTTP 403: <?xml version="1.0" encoding="UTF-8"?>
+<Error><Code>AccessDenied</Code><Message>Access Denied</Message></Error>
+======================================================================
+FAILED  3/43 checks failed
+======================================================================
+Error: Process completed with exit code 1.
+
+### [61] 2026-03-10 16:02
+
+Smoke tests — __https://91x4s2av9d.execute-api.us-east-1.amazonaws.com/prod__
+======================================================================
+── Locations ──────────────────────────────────────────────────────────
+✓  GET /locations → 200
+✓  response has 'locations' array
+✓  response has 'count' field
+✓  CollinTx is present
+✓  GET /locations/CollinTx → 200
+✓  locationCode == CollinTx
+✓  locationPath == collin-tx
+✓  locationName is present
+✓  searchUrl is present
+✓  GET /locations/DoesNotExist999 → 404
+── Documents ──────────────────────────────────────────────────────────
+✓  GET /collin-tx/documents → 200
+✓  response has 'documents' array
+✓  response has 'location' object
+✓  response has 'count' field
+✓  response has 'query' field
+✓  GET /collin-tx/documents?limit=2 → 200
+✓  at most 2 documents returned
+✓  GET /no-such-county/documents → 404
+✓  GET /collin-tx/documents (no dates) → 200
+✓  no-date response has 'documents' array
+── Users ──────────────────────────────────────────────────────────────
+✓  POST /users → 201
+✓  response has userId
+✓  email matches
+✓  status is active
+✓  locationCodes is a list
+✓  POST /users (no email) → 400
+✓  POST /users (bad location) → 422
+✓  GET /users/{id} → 200
+✓  userId matches
+✓  email matches
+✓  PATCH /users/{id} → 200
+✓  status updated to inactive
+✓  PATCH /users/{id} (bad status) → 400
+✓  DELETE /users/{id} → 200
+✓  status set to inactive on delete
+✓  GET /users/nonexistent → 404
+✓  GET /users (no API key) → 403
+── Stripe webhook ─────────────────────────────────────────────────────
+✓  POST /stripe/webhook is reachable (200 or 400)
+── Auth / CORS ─────────────────────────────────────────────────────────
+✗  OPTIONS /auth/request-login (no API key) → 200 or 204
+HTTP 403: {"message":"Forbidden"}
+✓  POST /auth/request-login (no API key) → 200
+✓  GET /auth/verify (bad token) → 401
+======================================================================
+FAILED  1/41 checks failed
+======================================================================
+Error: Process completed with exit code 1.
+
+### [62] 2026-03-10 20:43
+
+how do i configure cloudflare
+
+### [63] 2026-03-10 21:48
+
+what is the api-key
+is the admin@collincountyleads.com user inserted
+is CollinTx inserted
+
+### [64] 2026-03-10 22:07
+
+how is claude session saved
+
+### [65] 2026-03-10 22:09
+
+ui dashboard on aws says "loading"
+
+### [66] 2026-03-11 09:38
+
+magic link doesn't work, redirects to login
+copy document files from backup s3 bucket to current bucket
+
+### [67] 2026-03-11 10:05
+
+[Request interrupted by user for tool use]
+
+### [68] 2026-03-11 10:05
+
+change to admin role
+
+### [69] 2026-03-11 10:09
+
+it goes to admin/users
+but Failed to load users.
+my dashboard redirects to login
+
+### [70] 2026-03-11 10:20
+
+continue to fix
+
+### [71] 2026-03-11 16:39
+
+UPDATE_FAILED            AWS::ApiGateway::RestA   ProbateApi               Resource handler
+                         pi                                                returned message:
+                                                                           "Errors found during
+                                                                           import:         Unable
+                                                                           to create resource at
+                                                                           path '/real-
+                                                                           estate/probate-
+                                                                           leads/{proxy+}': A
+                                                                           sibling
+                                                                           ({location_path}) of
+                                                                           this resource already
+                                                                           has a variable path
+                                                                           part -- only one is
+                                                                           allowed (Service:
+                                                                           ApiGateway, Status
+                                                                           Code: 400, Request ID:
+                                                                           8562110a-0a8e-4472-
+                                                                           9e16-b3252a6c0e7e)
+                                                                           (SDK Attempt Count:
+                                                                           1)" (RequestToken: b89
+                                                                           28e13-c796-cb14-17db-
+                                                                           084c77db9d34,
+                                                                           HandlerErrorCode:
+                                                                           InvalidRequest)
+UPDATE_ROLLBACK_IN_PRO   AWS::CloudFormation::S   probate-scraper          The following
+GRESS                    tack                                              resource(s) failed to
+                                                                           update: [ProbateApi].
+
+### [72] 2026-03-11 16:42
+
+new pr, it's already merged
+
+### [73] 2026-03-11 19:29
+
+CREATE_FAILED            AWS::Lambda::Permissio   ApiFunctionOptionsStri   Resource handler
+                         n                        peCheckoutPermissionpr   returned message: "The
+                                                  od                       final policy size
+                                                                           (20548) is bigger than
+                                                                           the limit (20480).
+                                                                           (Service: Lambda,
+                                                                           Status Code: 400,
+                                                                           Request ID: 9ecc8565-
+                                                                           3cef-43b7-b3bb-
+                                                                           92035ab8c78c) (SDK
+                                                                           Attempt Count: 1)"
+                                                                           (RequestToken: a8698ec
+                                                                           7-dcdb-3ac6-e5d7-
+                                                                           4966d7458a8e,
+                                                                           HandlerErrorCode:
+                                                                           InvalidRequest)
+UPDATE_FAILED            AWS::ApiGateway::Stage   ProbateApiprodStage      Resource update
+                                                                           cancelled
+UPDATE_ROLLBACK_IN_PRO   AWS::CloudFormation::S   probate-scraper          The following
+GRESS                    tack                                              resource(s) failed to
+                                                                           create: [ApiFunctionOp
+                                                                           tionsStripeCheckoutPer
+                                                                           missionprod]. The
+                                                                           following resource(s)
+                                                                           failed to update:
+                                                                           [ProbateApiprodStage].
+UPDATE_IN_PROGRESS       AWS::Lambda::Function    TriggerFunction          -

--- a/docs/sessions/2026-03-07-eb727ffa.md
+++ b/docs/sessions/2026-03-07-eb727ffa.md
@@ -1,0 +1,23 @@
+# Session eb727ffa
+
+**Date:** 2026-03-07  
+**Branch:** feature/prospect-email  
+**Session ID:** eb727ffa-e7ef-4d74-8bfc-1e9ebcd035c5  
+
+_3 prompts_
+
+---
+
+### [1] 2026-03-07 16:27
+
+pr
+
+### [2] 2026-03-07 16:29
+
+git status
+error: read error while indexing .github/workflows/ci.yml: Operation timed out
+fatal: mmap failed: Operation timed out
+
+### [3] 2026-03-07 16:34
+
+update local files and ci.yml from github

--- a/docs/sessions/2026-03-11-c4aa41be.md
+++ b/docs/sessions/2026-03-11-c4aa41be.md
@@ -1,0 +1,178 @@
+# Session c4aa41be
+
+**Date:** 2026-03-11  
+**Branch:** feature/enrich-leads  
+**Session ID:** c4aa41be-2ebd-4f28-90c4-d429c70c7de2  
+
+_19 prompts_
+
+---
+
+### [1] 2026-03-11 22:50
+
+CREATE_FAILED            AWS::Lambda::Permissio   ApiFunctionOptionsStri   Resource handler
+                         n                        peCheckoutPermissionpr   returned message: "The
+                                                  od                       final policy size
+                                                                           (20548) is bigger than
+                                                                           the limit (20480).
+                                                                           (Service: Lambda,
+                                                                           Status Code: 400,
+                                                                           Request ID: 9ecc8565-
+                                                                           3cef-43b7-b3bb-
+                                                                           92035ab8c78c) (SDK
+                                                                           Attempt Count: 1)"
+                                                                           (RequestToken: a8698ec
+                                                                           7-dcdb-3ac6-e5d7-
+                                                                           4966d7458a8e,
+                                                                           HandlerErrorCode:
+                                                                           InvalidRequest)
+UPDATE_FAILED            AWS::ApiGateway::Stage   ProbateApiprodStage      Resource update
+                                                                           cancelled
+UPDATE_ROLLBACK_IN_PRO   AWS::CloudFormation::S   probate-scraper          The following
+GRESS                    tack                                              resource(s) failed to
+                                                                           create: [ApiFunctionOp
+                                                                           tionsStripeCheckoutPer
+                                                                           missionprod]. The
+                                                                           following resource(s)
+                                                                           failed to update:
+                                                                           [ProbateApiprodStage].
+
+### [2] 2026-03-11 23:01
+
+new pr
+
+### [3] 2026-03-11 23:19
+
+Smoke tests — __https://91x4s2av9d.execute-api.us-east-1.amazonaws.com/prod__
+======================================================================
+── Locations ──────────────────────────────────────────────────────────
+✓  GET /locations → 200
+✓  response has 'locations' array
+✓  response has 'count' field
+✓  CollinTx is present
+✓  GET /locations/CollinTx → 200
+✓  locationCode == CollinTx
+✓  locationPath == collin-tx
+✓  locationName is present
+✓  searchUrl is present
+✓  GET /locations/DoesNotExist999 → 404
+── Documents ──────────────────────────────────────────────────────────
+✓  GET /collin-tx/documents → 200
+✓  response has 'documents' array
+✓  response has 'location' object
+✓  response has 'count' field
+✓  response has 'query' field
+✓  document has docNumber
+✓  document has recordedDate
+✓  document has locationCode
+✓  GET /collin-tx/documents?limit=2 → 200
+✓  at most 2 documents returned
+✓  GET /no-such-county/documents → 404
+✓  GET /collin-tx/documents (no dates) → 200
+✓  no-date response has 'documents' array
+── Users ──────────────────────────────────────────────────────────────
+✓  POST /users → 201
+✓  response has userId
+✓  email matches
+✓  status is active
+✓  locationCodes is a list
+✓  POST /users (no email) → 400
+✓  POST /users (bad location) → 422
+✓  GET /users/{id} → 200
+✓  userId matches
+✓  email matches
+✓  PATCH /users/{id} → 200
+✓  status updated to inactive
+✓  PATCH /users/{id} (bad status) → 400
+✓  DELETE /users/{id} → 200
+✓  status set to inactive on delete
+✓  GET /users/nonexistent → 404
+✓  GET /users (no API key) → 403
+── Stripe webhook ─────────────────────────────────────────────────────
+✓  POST /stripe/webhook is reachable (200 or 400)
+── Auth / CORS ─────────────────────────────────────────────────────────
+✗  OPTIONS /auth/request-login (no API key) → 200 or 204
+HTTP 403: {"message":"Forbidden"}
+✓  POST /auth/request-login (no API key) → 200
+✓  GET /auth/verify (bad token) → 401
+======================================================================
+FAILED  1/44 checks failed
+
+### [4] 2026-03-11 23:33
+
+new pr
+
+### [5] 2026-03-11 23:36
+
+Template provided at '/home/runner/work/probate-scraper/probate-scraper/template.yaml' was invalid SAM Template.
+Error: [InvalidResourceException('ApiFunction', 'Event with id [AdminProspectSend] is invalid. Unable to set ApiKeyRequired [False] on API method [post] for path [/real-estate/probate-leads/admin/prospect/send] because the related API does not specify any ApiKeyRequired.')] ('ApiFunction', 'Event with id [AdminProspectSend] is invalid. Unable to set ApiKeyRequired [False] on API method [post] for path [/real-estate/probate-leads/admin/prospect/send] because the related API does not specify any ApiKeyRequired.')
+Error: Process completed with exit code 1.
+
+### [6] 2026-03-11 23:40
+
+new pr
+
+### [7] 2026-03-11 23:57
+
+run make backfill-s3-uris
+
+### [8] 2026-03-12 00:06
+
+in ui dashboard 
+remove grantee and deceased
+add column for doc with icon when docS3Uri is not null
+
+### [9] 2026-03-12 00:16
+
+remember: after completing work, commit push pr
+
+### [10] 2026-03-12 00:18
+
+but 94 is already merged
+
+### [11] 2026-03-12 00:19
+
+[Request interrupted by user for tool use]
+
+### [12] 2026-03-12 00:19
+
+why
+
+### [13] 2026-03-12 00:21
+
+why is the gh workflow not consistent? when completing work, commit, push, and pr
+after you make a pr, i will merge it
+don't assume a commit goes to that pr, it is already closed
+
+### [14] 2026-03-12 00:22
+
+why would a merged pr capture new commits? how would that work
+
+### [15] 2026-03-12 00:32
+
+there are 21 files in the documents bucket, but only 5 docS3Uri in the table. 
+why is this? is the docS3Uri field being overwritten in a new scrape? only changed fields should be updated
+insert the missing docS3Uri references
+
+### [16] 2026-03-12 00:37
+
+are there files in
+s3://probate-documents-backup/documents/CollinTx/
+that are not in the documents bucket
+if so add them and add the doc_s3_uri to the table
+
+### [17] 2026-03-12 00:47
+
+after i parse-document i want to edit contacts and properties
+but i want to keep the original values
+to use for training and to improve the prompt
+the edited values become a "golden dataset"
+make recommendations for how to store original and edited contacts and properties that will make it easy to use in this way
+
+### [18] 2026-03-12 00:51
+
+implement but use no (safer)
+
+### [19] 2026-03-12 11:18
+
+resume

--- a/docs/sessions/2026-03-13-90fb8139.md
+++ b/docs/sessions/2026-03-13-90fb8139.md
@@ -1,0 +1,13 @@
+# Session 90fb8139
+
+**Date:** 2026-03-13  
+**Branch:** feature/enrich-leads  
+**Session ID:** 90fb8139-65bd-4eb0-b123-9cbec70a920a  
+
+_1 prompt_
+
+---
+
+### [1] 2026-03-13 12:25
+
+resume

--- a/docs/sessions/2026-03-13-99637e6c.md
+++ b/docs/sessions/2026-03-13-99637e6c.md
@@ -1,0 +1,151 @@
+# Session 99637e6c
+
+**Date:** 2026-03-13  
+**Branch:** feature/enrich-leads  
+**Session ID:** 99637e6c-75dd-4fc3-96c2-234838891c38  
+
+_29 prompts_
+
+---
+
+### [1] 2026-03-13 12:27
+
+is there a previous session
+
+### [2] 2026-03-13 12:32
+
+after the document parser reads contacts and properties
+i need to review and correct
+but i want to keep the original parsed version
+so i can improve the prompt iteratively by comparing the parsed content with the corrected content like a golden dataset
+you were adding fields to the models such as parsed_role
+please review and complete the feature
+
+### [3] 2026-03-13 13:20
+
+what is the test coverage
+
+### [4] 2026-03-13 13:22
+
+add more tests
+
+### [5] 2026-03-13 14:01
+
+new pr
+
+### [6] 2026-03-13 14:04
+
+is stripe configured
+
+### [7] 2026-03-13 14:08
+
+can i store them in github secrets
+
+### [8] 2026-03-13 14:39
+
+bedrock returned an address string as "6502 Star Creek, Frisco, Texas 75034, Collin County, Texas"
+what are options to parse this into a real address
+is it recommended to add this to the existing prompt
+is geocoding an option
+are there free or cheap address services that can be integrated
+
+### [9] 2026-03-13 14:49
+
+do 1 and 2
+add is_verified to the properties table and an icon to the ui if an address passes
+
+### [10] 2026-03-13 18:47
+
+in the first 4 records, when i parsed there was no property listed
+this may be because the new prompt is too strict
+keep the address parts parsing but make a fallback if the address string cannot be easily separated into parts
+
+### [11] 2026-03-13 20:14
+
+when POST documents/{document_id}/parse-document
+if the document was already parsed
+first clear contacts and properties
+so the new result replaces the old
+
+### [12] 2026-03-13 20:29
+
+new pr
+
+### [13] 2026-03-13 21:15
+
+the results of document parsing are not shown in the ui
+the processed_at field should be updated when the document is parsed
+add a field in the ui to show the raw parsing result
+
+### [14] 2026-03-13 21:22
+
+new pr
+
+### [15] 2026-03-13 21:30
+
+https://collincountyleads.com/documents/5aae5fda-9ef7-5460-a104-449ef3c894c7
+Bedrock call failed: No valid JSON in model response: '{\n "deceased_name": "LEE ROY PRICE",\n "deceased_dob": null,\n "deceased_dod": "1993-06-22",\n "deceased_last_address": "103 Crocket, Garland, Dallas County, Texas",\n "people": [\n {\n "name": "DIANN SUE PRICE",\n "role": "executor / beneficiary",\n "email": null\n },\n {\n "'
+
+### [16] 2026-03-13 21:41
+
+why no pr?
+
+### [17] 2026-03-13 22:07
+
+https://collincountyleads.com/documents/5aae5fda-9ef7-5460-a104-449ef3c894c7
+An error occurred (AccessDeniedException) when calling the Query operation: User: arn:aws:sts::600775874112:assumed-role/probate-scraper-ParseDocumentFunctionRole-syj8fuLgEauw/probate-leads-parse-document is not authorized to perform: dynamodb:Query on resource: arn:aws:dynamodb:us-east-1:600775874112:table/contacts/index/document-contact-index because no identity-based policy allows the dynamodb:Query action
+
+### [18] 2026-03-14 11:05
+
+would using orm make the app better
+
+### [19] 2026-03-14 11:08
+
+add _dynamo_update_expression(updates: dict)
+look for other simplification and refactoring opportunities and suggest
+
+### [20] 2026-03-14 11:13
+
+no. new pr
+
+### [21] 2026-03-14 11:27
+
+new branch, new feature
+add a child element to property and contact for links, references and additional information such as a link maybe zillow to look up the real estate, an obituary, and other information
+avoid duplicates in contacts and properties. if the same person has several roles, choose the most important and put the others in notes. capitalize names nicely reusing the helper in the prospects insert.
+suggest options for real estate links
+suggest options for searching the web for an obituary
+
+### [22] 2026-03-14 12:25
+
+update readme
+
+### [23] 2026-03-14 12:55
+
+after adding a property, if the address is valid, insert the google search link for the property into the links table
+in the property view, show the link as a google icon
+after adding a deceased, insert a legacy.com link to search for their obituary. show that on the contacts page with a legacy.com icon
+
+### [24] 2026-03-14 13:09
+
+commit push
+
+### [25] 2026-03-14 13:09
+
+pr
+
+### [26] 2026-03-14 13:11
+
+in the properties and contacts view, change edit, delete, and add link to icons and put them in a row on the right
+
+### [27] 2026-03-14 16:48
+
+resum
+
+### [28] 2026-03-14 17:59
+
+new pr
+
+### [29] 2026-03-14 20:28
+
+save session

--- a/docs/sessions/2026-03-15-a260af0f.md
+++ b/docs/sessions/2026-03-15-a260af0f.md
@@ -1,0 +1,29 @@
+# Session a260af0f
+
+**Date:** 2026-03-15  
+**Branch:** feature/links-dedup-enrichment  
+**Session ID:** a260af0f-d793-47d1-96bf-4a6414d22a5c  
+
+_5 prompts_
+
+---
+
+### [1] 2026-03-15 08:10
+
+look through github history and summarize the project development. include observations about velocity, design, use of ai, and estimate how close we are to having an mvp for our first subscribers
+
+### [2] 2026-03-15 08:59
+
+i want to keep a record of prompt history within the project. to better understand the designers intention, for instance in pr review, and for analysis afterwards.  make recommendation
+
+### [3] 2026-03-15 09:25
+
+yes
+
+### [4] 2026-03-15 09:39
+
+when does a session end? what happens if i restart the computer?
+
+### [5] 2026-03-15 09:41
+
+what observations and recommendations are there from reviewing the sessino history

--- a/scripts/extract_session.py
+++ b/scripts/extract_session.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""
+Claude Code Stop hook — extracts user prompts from the current session
+and writes a readable markdown log to docs/sessions/.
+
+Runs automatically at the end of every Claude session. Configure in
+.claude/settings.json:
+  { "hooks": { "Stop": [{ "hooks": [{ "type": "command",
+      "command": "python3 scripts/extract_session.py" }] }] } }
+"""
+
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def main():
+    payload = json.load(sys.stdin)
+
+    # Don't block Claude from stopping — always exit 0
+    # (stop_hook_active=true means Claude is already in a stop hook response loop)
+    if payload.get("stop_hook_active"):
+        sys.exit(0)
+
+    transcript_path = payload.get("transcript_path", "")
+    session_id = payload.get("session_id", "unknown")
+    cwd = payload.get("cwd", os.getcwd())
+
+    if not transcript_path or not Path(transcript_path).exists():
+        sys.exit(0)
+
+    # Parse the session JSONL
+    entries = []
+    with open(transcript_path) as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                try:
+                    entries.append(json.loads(line))
+                except json.JSONDecodeError:
+                    pass
+
+    # Extract user prompts
+    prompts = []
+    git_branch = None
+
+    for entry in entries:
+        # Grab git branch from any entry that has it
+        if not git_branch and entry.get("gitBranch"):
+            git_branch = entry["gitBranch"]
+
+        if entry.get("type") != "user":
+            continue
+
+        content = entry.get("message", {}).get("content", "")
+        timestamp = entry.get("timestamp", "")
+
+        # Parse timestamp
+        try:
+            ts = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+            ts_str = ts.astimezone().strftime("%Y-%m-%d %H:%M")
+        except Exception:
+            ts_str = timestamp[:16] if timestamp else ""
+
+        # Content can be a string or a list of content blocks
+        if isinstance(content, str):
+            text = content.strip()
+        elif isinstance(content, list):
+            # Collect text blocks; skip tool_result blocks (those are Claude's tool outputs)
+            parts = []
+            for block in content:
+                if not isinstance(block, dict):
+                    continue
+                if block.get("type") == "tool_result":
+                    continue
+                if block.get("type") == "text":
+                    parts.append(block.get("text", "").strip())
+            text = "\n".join(p for p in parts if p)
+        else:
+            continue
+
+        if not text:
+            continue
+
+        # Skip injected system reminders
+        if text.startswith("<system-reminder"):
+            continue
+        # Skip if it's only a system reminder (wrapped in tags)
+        if re.match(r"^\s*<system-reminder[\s\S]*?</system-reminder>\s*$", text):
+            continue
+        # Strip leading system-reminder blocks that precede the real prompt
+        text = re.sub(r"<system-reminder[\s\S]*?</system-reminder>\s*", "", text).strip()
+        if not text:
+            continue
+        # Skip Claude-injected context summaries (session continuation boilerplate)
+        if text.startswith("This session is being continued from a previous conversation"):
+            continue
+
+        prompts.append({"ts": ts_str, "text": text})
+
+    if not prompts:
+        sys.exit(0)
+
+    # Determine output path
+    project_dir = Path(cwd)
+    sessions_dir = project_dir / "docs" / "sessions"
+    sessions_dir.mkdir(parents=True, exist_ok=True)
+
+    # File name: date + short session ID
+    session_date = prompts[0]["ts"][:10] if prompts else datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    short_id = session_id[:8]
+    out_path = sessions_dir / f"{session_date}-{short_id}.md"
+
+    # Build markdown
+    lines = [
+        f"# Session {short_id}",
+        "",
+        f"**Date:** {session_date}  ",
+        f"**Branch:** {git_branch or 'unknown'}  ",
+        f"**Session ID:** {session_id}  ",
+        "",
+        f"_{len(prompts)} prompt{'s' if len(prompts) != 1 else ''}_",
+        "",
+        "---",
+        "",
+    ]
+
+    for i, p in enumerate(prompts, 1):
+        lines.append(f"### [{i}] {p['ts']}")
+        lines.append("")
+        # Indent multi-line prompts cleanly
+        lines.append(p["text"])
+        lines.append("")
+
+    out_path.write_text("\n".join(lines))
+
+
+if __name__ == "__main__":
+    main()

--- a/ui/src/pages/DocumentDetail.tsx
+++ b/ui/src/pages/DocumentDetail.tsx
@@ -50,6 +50,21 @@ function roleBadgeVariant(role: string): 'default' | 'secondary' | 'outline' {
   return 'outline'
 }
 
+const ROLE_ORDER: Record<string, number> = {
+  deceased: 0,
+  executor: 1,
+  spouse:   2,
+  family:   3,
+}
+
+function roleOrder(role: string): number {
+  return ROLE_ORDER[role?.toLowerCase()] ?? 4
+}
+
+function sortContacts(contacts: Contact[]): Contact[] {
+  return [...contacts].sort((a, b) => roleOrder(a.role) - roleOrder(b.role))
+}
+
 // ---------------------------------------------------------------------------
 // Link helpers
 // ---------------------------------------------------------------------------
@@ -89,7 +104,7 @@ function contactLinkSuggestions(contact: Contact): Suggestion[] {
   const last   = encodeURIComponent(parts.length > 1 ? parts[parts.length - 1] : '')
   const full   = encodeURIComponent(name)
   return [
-    { label: 'Legacy.com',      url: `https://www.legacy.com/search?name=${full}`,                                                      linkType: 'legacy' },
+    // { label: 'Legacy.com', url: `https://www.legacy.com/search?name=${full}`, linkType: 'legacy' }, // disabled — search not reliable
     { label: 'FindAGrave',      url: `https://www.findagrave.com/memorial/search?firstname=${first}&lastname=${last}`,                  linkType: 'findagrave' },
     { label: 'Obituaries.com',  url: `https://www.obituaries.com/search/results/?fname=${first}&lname=${last}`,                        linkType: 'obituary' },
     { label: 'Google obituary', url: `https://www.google.com/search?q=${full}+obituary`,                                               linkType: 'obituary' },
@@ -97,7 +112,7 @@ function contactLinkSuggestions(contact: Contact): Suggestion[] {
 }
 
 // ---------------------------------------------------------------------------
-// LinkChip
+// LinkIcon — inline favicon icon for a saved link
 // ---------------------------------------------------------------------------
 
 const LINK_FAVICONS: Record<string, string> = {
@@ -111,29 +126,30 @@ const LINK_FAVICONS: Record<string, string> = {
   findagrave:    'https://www.google.com/s2/favicons?domain=findagrave.com&sz=16',
 }
 
-function LinkChip({ link, onDelete }: { link: Link; onDelete: () => void }) {
+function LinkIcon({ link, onDelete }: { link: Link; onDelete: () => void }) {
   const favicon = LINK_FAVICONS[link.linkType]
+  const label = link.label || LINK_TYPE_LABELS[link.linkType] || 'Link'
   return (
-    <span className="group inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+    <span className="group relative inline-flex shrink-0">
       <a
         href={link.url}
         target="_blank"
         rel="noopener noreferrer"
-        className="flex items-center gap-1 hover:text-foreground"
+        title={label}
+        className="flex items-center opacity-70 hover:opacity-100"
       >
         {favicon
-          ? <img src={favicon} alt="" className="h-3 w-3 shrink-0" />
-          : <ExternalLink size={10} />
+          ? <img src={favicon} alt={label} className="h-3.5 w-3.5" />
+          : <ExternalLink size={12} className="text-muted-foreground" />
         }
-        {link.label || LINK_TYPE_LABELS[link.linkType] || 'Link'}
       </a>
       <button
         type="button"
         onClick={onDelete}
-        className="ml-0.5 opacity-0 transition-opacity group-hover:opacity-100 hover:text-destructive"
-        aria-label="Remove link"
+        aria-label={`Remove ${label}`}
+        className="absolute -right-1 -top-1 hidden h-3 w-3 items-center justify-center rounded-full bg-destructive text-white group-hover:flex"
       >
-        <X size={10} />
+        <X size={6} />
       </button>
     </span>
   )
@@ -486,7 +502,18 @@ function ContactRow({
             {contact.role}
           </Badge>
         </TableCell>
-        <TableCell className="font-medium whitespace-nowrap">{contact.name || '—'}</TableCell>
+        <TableCell className="font-medium whitespace-nowrap">
+          <span className="flex items-center gap-1.5">
+            {contact.name || '—'}
+            {links.map(link => (
+              <LinkIcon
+                key={link.linkId}
+                link={link}
+                onDelete={() => deleteLinkMut.mutate(link.linkId)}
+              />
+            ))}
+          </span>
+        </TableCell>
         <TableCell className="text-sm">{contact.email || '—'}</TableCell>
         <TableCell className="whitespace-nowrap text-sm">{contact.dob || '—'}</TableCell>
         <TableCell className="whitespace-nowrap text-sm">{contact.dod || '—'}</TableCell>
@@ -514,23 +541,6 @@ function ContactRow({
           </div>
         </TableCell>
       </TableRow>
-
-      {/* Links sub-row */}
-      {links.length > 0 && (
-        <TableRow className="hover:bg-transparent border-t-0">
-          <TableCell colSpan={8} className="pb-2 pt-0 pl-6">
-            <div className="flex flex-wrap items-center gap-1.5">
-              {links.map(link => (
-                <LinkChip
-                  key={link.linkId}
-                  link={link}
-                  onDelete={() => deleteLinkMut.mutate(link.linkId)}
-                />
-              ))}
-            </div>
-          </TableCell>
-        </TableRow>
-      )}
 
       {editOpen && (
         <EditContactDialog
@@ -600,7 +610,7 @@ function ContactsSection({
               </TableRow>
             </TableHeader>
             <TableBody>
-              {contacts.map(c => (
+              {sortContacts(contacts).map(c => (
                 <ContactRow
                   key={c.contactId}
                   documentId={documentId}
@@ -647,12 +657,17 @@ function PropertyRow({
           <span className="flex items-center gap-1.5">
             {property.address || '—'}
             {property.isVerified && (
-              <CheckCircle
-                className="shrink-0 text-green-500"
-                size={14}
-                aria-label="Address verified"
-              />
+              <span title="Address verified — parsed and confirmed by address validator">
+                <CheckCircle className="shrink-0 text-green-500" size={14} />
+              </span>
             )}
+            {links.map(link => (
+              <LinkIcon
+                key={link.linkId}
+                link={link}
+                onDelete={() => deleteLinkMut.mutate(link.linkId)}
+              />
+            ))}
           </span>
         </TableCell>
         <TableCell>{property.city || '—'}</TableCell>
@@ -682,23 +697,6 @@ function PropertyRow({
           </div>
         </TableCell>
       </TableRow>
-
-      {/* Links sub-row */}
-      {links.length > 0 && (
-        <TableRow className="hover:bg-transparent border-t-0">
-          <TableCell colSpan={7} className="pb-2 pt-0 pl-6">
-            <div className="flex flex-wrap items-center gap-1.5">
-              {links.map(link => (
-                <LinkChip
-                  key={link.linkId}
-                  link={link}
-                  onDelete={() => deleteLinkMut.mutate(link.linkId)}
-                />
-              ))}
-            </div>
-          </TableCell>
-        </TableRow>
-      )}
 
       {editOpen && (
         <EditPropertyDialog


### PR DESCRIPTION
## Summary

- **AI-parsed contacts and properties** from PDF documents via Bedrock (Nova Pro)
- **Auto-enrichment** — Google Maps and Legacy.com links inserted on parse; name capitalisation; contact dedup
- **Inline link icons** — favicon icons appear next to contact name / property address; links sub-rows removed
- **Contact sort order** — deceased → executor → spouse → family → other
- **Address verification** — `is_verified` field with checkmark icon and tooltip
- **Golden dataset** — original parsed values preserved alongside human-corrected values for prompt iteration
- **Session prompt logging** — Stop hook writes user prompts to `docs/sessions/` after every response

## Prompt history

See `docs/sessions/2026-03-15-a260af0f.md` and `docs/sessions/2026-03-13-99637e6c.md` for the conversations that produced this work.

## Test plan

- [ ] Parse a document and confirm contacts appear sorted (deceased first)
- [ ] Confirm link favicons appear inline next to name / address
- [ ] Hover a link favicon — confirm × delete badge appears
- [ ] Hover the green checkmark on a verified address — confirm tooltip text
- [ ] Open Add link dialog — confirm Legacy.com is absent from suggestions
- [ ] Check `docs/sessions/` for a new file after this session ends

🤖 Generated with [Claude Code](https://claude.ai/claude-code)