### PR TITLE
fix: resolve TypeScript error in TrialBanner component

### DIFF
--- a/ui/src/components/trial-banner.tsx
+++ b/ui/src/components/trial-banner.tsx
@@ -39,11 +39,16 @@ interface TrialBannerProps {
 
 export function TrialBanner({ onSubscribe }: TrialBannerProps) {
   const { payload } = useAuth()
-  const userId = payload?.sub
+  const userId = payload?.sub as string | undefined
 
   const { data: trialData } = useQuery({
     queryKey: ['trialStatus', userId],
-    queryFn: () => userId ? getTrialStatus(userId) : Promise.reject('No user ID'),
+    queryFn: () => {
+      if (!userId) {
+        return Promise.reject('No user ID')
+      }
+      return getTrialStatus(userId)
+    },
     enabled: !!userId,
     refetchInterval: 1000 * 60 * 60, // Refetch every hour
   })


### PR DESCRIPTION
## Problem

After PR #112 was merged, the TypeScript build is failing with:
```
src/components/trial-banner.tsx(46,44): error TS2345: Argument of type '{}' is not assignable to parameter of type 'string'
```

## Root Cause

The `payload?.sub` property from `useAuth()` has type `unknown` (from `Record<string, unknown>`), but the `getTrialStatus()` function expects a `string` parameter.

## Solution

- **Type assertion**: Added `as string | undefined` to properly type `userId`
- **Explicit validation**: Updated `queryFn` to use explicit conditional check instead of ternary operator
- **Better TypeScript inference**: Cleaner type flow for React Query

## Changes

```typescript
// Before
const userId = payload?.sub
queryFn: () => userId ? getTrialStatus(userId) : Promise.reject('No user ID'),

// After  
const userId = payload?.sub as string | undefined
queryFn: () => {
  if (!userId) {
    return Promise.reject('No user ID')
  }
  return getTrialStatus(userId)
},
```

## Testing

✅ **TypeScript build now succeeds**:
```bash
> npm run build
✓ built in 2.35s
```

✅ **No functional changes** - component behavior remains identical
✅ **Type safety maintained** - proper handling of undefined userId

## Impact

- **Fixes CI/CD pipeline** - UI builds will no longer fail
- **Enables development** - Local TypeScript compilation works
- **No runtime changes** - Same component functionality

Small but critical fix to unblock development and deployment.