### PR TITLE
Enformion contact enrichment on parse

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -180,6 +180,8 @@ jobs:
           STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
           RESEND_WEBHOOK_SECRET: ${{ secrets.RESEND_WEBHOOK_SECRET }}
+          ENFORMION_AP_NAME: ${{ secrets.ENFORMION_AP_NAME }}
+          ENFORMION_AP_PASSWORD: ${{ secrets.ENFORMION_AP_PASSWORD }}
           USERNAME_COLLINTX: ${{ secrets.USERNAME_COLLINTX }}
           PASSWORD_COLLINTX: ${{ secrets.PASSWORD_COLLINTX }}
           MAGIC_LINK_BASE_URL: ${{ vars.MAGIC_LINK_BASE_URL || 'https://collincountyleads.com/auth/verify' }}
@@ -210,6 +212,8 @@ jobs:
           [ -n "$STRIPE_WEBHOOK_SECRET" ] && OVERRIDES+=("StripeWebhookSecret=$STRIPE_WEBHOOK_SECRET")
           [ -n "$RESEND_API_KEY" ]        && OVERRIDES+=("ResendApiKey=$RESEND_API_KEY")
           [ -n "$RESEND_WEBHOOK_SECRET" ] && OVERRIDES+=("ResendWebhookSecret=$RESEND_WEBHOOK_SECRET")
+          [ -n "$ENFORMION_AP_NAME" ]     && OVERRIDES+=("EnformionApName=$ENFORMION_AP_NAME")
+          [ -n "$ENFORMION_AP_PASSWORD" ] && OVERRIDES+=("EnformionApPassword=$ENFORMION_AP_PASSWORD")
           [ -n "$USERNAME_COLLINTX" ]     && OVERRIDES+=("ScraperUsername=$USERNAME_COLLINTX")
           [ -n "$PASSWORD_COLLINTX" ]     && OVERRIDES+=("ScraperPassword=$PASSWORD_COLLINTX")
 

--- a/src/api/models.py
+++ b/src/api/models.py
@@ -144,54 +144,73 @@ class Contact:
     parsed_dod:     str = ""
     parsed_address: str = ""
     parsed_notes:   str = ""
+    # ── Enformion enrichment fields ────────────────────────────────────────
+    enrichment_status:       str = ""  # success | no_match | error | skipped
+    enriched_at:             str = ""  # ISO timestamp of enrichment attempt
+    enriched_phone:          str = ""
+    enriched_email:          str = ""
+    enriched_name:           str = ""
+    enriched_identity_score: str = ""
 
     @classmethod
     def from_dynamo(cls, item: dict) -> "Contact":
         return cls(
-            contact_id=     item.get("contact_id", ""),
-            document_id=    item.get("document_id", ""),
-            role=           item.get("role", ""),
-            name=           item.get("name", ""),
-            email=          item.get("email", ""),
-            dob=            item.get("dob", ""),
-            dod=            item.get("dod", ""),
-            address=        item.get("address", ""),
-            notes=          item.get("notes", ""),
-            edited_at=      item.get("edited_at", ""),
-            parsed_at=      item.get("parsed_at", ""),
-            parsed_model=   item.get("parsed_model", ""),
-            raw_response=   item.get("raw_response", ""),
-            parsed_role=    item.get("parsed_role", ""),
-            parsed_name=    item.get("parsed_name", ""),
-            parsed_email=   item.get("parsed_email", ""),
-            parsed_dob=     item.get("parsed_dob", ""),
-            parsed_dod=     item.get("parsed_dod", ""),
-            parsed_address= item.get("parsed_address", ""),
-            parsed_notes=   item.get("parsed_notes", ""),
+            contact_id=              item.get("contact_id", ""),
+            document_id=             item.get("document_id", ""),
+            role=                    item.get("role", ""),
+            name=                    item.get("name", ""),
+            email=                   item.get("email", ""),
+            dob=                     item.get("dob", ""),
+            dod=                     item.get("dod", ""),
+            address=                 item.get("address", ""),
+            notes=                   item.get("notes", ""),
+            edited_at=               item.get("edited_at", ""),
+            parsed_at=               item.get("parsed_at", ""),
+            parsed_model=            item.get("parsed_model", ""),
+            raw_response=            item.get("raw_response", ""),
+            parsed_role=             item.get("parsed_role", ""),
+            parsed_name=             item.get("parsed_name", ""),
+            parsed_email=            item.get("parsed_email", ""),
+            parsed_dob=              item.get("parsed_dob", ""),
+            parsed_dod=              item.get("parsed_dod", ""),
+            parsed_address=          item.get("parsed_address", ""),
+            parsed_notes=            item.get("parsed_notes", ""),
+            enrichment_status=       item.get("enrichment_status", ""),
+            enriched_at=             item.get("enriched_at", ""),
+            enriched_phone=          item.get("enriched_phone", ""),
+            enriched_email=          item.get("enriched_email", ""),
+            enriched_name=           item.get("enriched_name", ""),
+            enriched_identity_score= item.get("enriched_identity_score", ""),
         )
 
     def to_dict(self) -> dict:
         return {
-            "contactId":     self.contact_id,
-            "documentId":    self.document_id,
-            "role":          self.role,
-            "name":          self.name,
-            "email":         self.email,
-            "dob":           self.dob,
-            "dod":           self.dod,
-            "address":       self.address,
-            "notes":         self.notes,
-            "editedAt":      self.edited_at,
-            "parsedAt":      self.parsed_at,
-            "parsedModel":   self.parsed_model,
-            "rawResponse":   self.raw_response,
-            "parsedRole":    self.parsed_role,
-            "parsedName":    self.parsed_name,
-            "parsedEmail":   self.parsed_email,
-            "parsedDob":     self.parsed_dob,
-            "parsedDod":     self.parsed_dod,
-            "parsedAddress": self.parsed_address,
-            "parsedNotes":   self.parsed_notes,
+            "contactId":             self.contact_id,
+            "documentId":            self.document_id,
+            "role":                  self.role,
+            "name":                  self.name,
+            "email":                 self.email,
+            "dob":                   self.dob,
+            "dod":                   self.dod,
+            "address":               self.address,
+            "notes":                 self.notes,
+            "editedAt":              self.edited_at,
+            "parsedAt":              self.parsed_at,
+            "parsedModel":           self.parsed_model,
+            "rawResponse":           self.raw_response,
+            "parsedRole":            self.parsed_role,
+            "parsedName":            self.parsed_name,
+            "parsedEmail":           self.parsed_email,
+            "parsedDob":             self.parsed_dob,
+            "parsedDod":             self.parsed_dod,
+            "parsedAddress":         self.parsed_address,
+            "parsedNotes":           self.parsed_notes,
+            "enrichmentStatus":      self.enrichment_status,
+            "enrichedAt":            self.enriched_at,
+            "enrichedPhone":         self.enriched_phone,
+            "enrichedEmail":         self.enriched_email,
+            "enrichedName":          self.enriched_name,
+            "enrichedIdentityScore": self.enriched_identity_score,
         }
 
 

--- a/src/parse_document/app.py
+++ b/src/parse_document/app.py
@@ -13,8 +13,9 @@ Flow:
   5. Parse the JSON response from Bedrock.
   6. Write contact records to the contacts table.
   7. Write property records to the properties table.
-  8. Stamp parsed_at + parse_error on the documents table.
-  9. Return a summary response.
+  8. Enrich up to 10 non-deceased contacts via Enformion (if credentials set).
+  9. Stamp parsed_at + parse_error on the documents table.
+  10. Return a summary response.
 
 Environment variables:
   DOCUMENTS_TABLE_NAME  — documents table (default: documents)
@@ -23,6 +24,8 @@ Environment variables:
   LINKS_TABLE_NAME      — links table (default: links)
   DOCUMENTS_BUCKET      — S3 bucket where PDFs are stored
   BEDROCK_MODEL_ID      — Bedrock model ID (default: us.amazon.nova-pro-v1:0)
+  ENFORMION_AP_NAME     — Enformion galaxy-ap-name credential
+  ENFORMION_AP_PASSWORD — Enformion galaxy-ap-password credential
   AWS_DEFAULT_REGION    — AWS region (injected by Lambda runtime)
 """
 
@@ -68,7 +71,9 @@ _model_id             = os.environ.get(
     "us.amazon.nova-pro-v1:0",
 )
 
-_links_table_name    = os.environ.get("LINKS_TABLE_NAME", "links")
+_links_table_name        = os.environ.get("LINKS_TABLE_NAME", "links")
+_enformion_ap_name       = os.environ.get("ENFORMION_AP_NAME", "")
+_enformion_ap_password   = os.environ.get("ENFORMION_AP_PASSWORD", "")
 
 _dynamodb          = boto3.resource("dynamodb", region_name=_region)
 _documents_table   = _dynamodb.Table(_documents_table_name)
@@ -242,13 +247,15 @@ def _call_bedrock(pdf_bytes: bytes) -> tuple[dict, str]:
 
 def _write_contacts(
     document_id: str, parsed: dict, model_id: str, parsed_at: str, raw_response: str
-) -> int:
+) -> tuple[int, list[dict]]:
     """
     Write one Contact record per person extracted from the document.
     Includes the deceased person (from deceased_* fields) + people list.
-    Returns the number of contacts written.
+    Returns (count_written, contacts_list) where contacts_list contains
+    dicts with at minimum contact_id, name, role (for enrichment).
     """
     written = 0
+    contacts: list[dict] = []
 
     # Deceased contact
     deceased_name    = _capitalize_name(parsed.get("deceased_name") or "")
@@ -282,6 +289,7 @@ def _write_contacts(
             "parsed_address": deceased_address,
             "parsed_notes":   "",
         })
+        contacts.append({"contact_id": deceased_contact_id, "name": deceased_name, "role": "deceased"})
         written += 1
         # Auto-insert a Legacy.com obituary search link for the deceased
         try:
@@ -310,8 +318,9 @@ def _write_contacts(
         role  = (person.get("role") or "other").lower()
         email = person.get("email") or ""
         notes = person.get("notes") or ""
+        contact_id = str(uuid.uuid4())
         _contacts_table.put_item(Item={
-            "contact_id":     str(uuid.uuid4()),
+            "contact_id":     contact_id,
             "document_id":    document_id,
             # editable (ground-truth) fields — start as the parsed values
             "role":           role,
@@ -335,9 +344,10 @@ def _write_contacts(
             "parsed_address": "",
             "parsed_notes":   notes,
         })
+        contacts.append({"contact_id": contact_id, "name": name, "role": role})
         written += 1
 
-    return written
+    return written, contacts
 
 
 def _try_usaddress(raw: str) -> tuple[str, str, str, bool]:
@@ -454,6 +464,36 @@ def _write_properties(
                 logger.warning("Failed to insert Google Maps link: %s", exc)
 
     return written
+
+
+def _apply_enrichment(enrichment_results: list[dict]) -> None:
+    """
+    Write Enformion enrichment results back to DynamoDB contacts table.
+    Uses UpdateItem so only enrichment columns are touched.
+    """
+    for result in enrichment_results:
+        contact_id = result.get("contact_id")
+        if not contact_id:
+            continue
+        try:
+            _contacts_table.update_item(
+                Key={"contact_id": contact_id},
+                UpdateExpression=(
+                    "SET enrichment_status = :es, enriched_at = :ea,"
+                    " enriched_phone = :ep, enriched_email = :ee,"
+                    " enriched_name = :en, enriched_identity_score = :ei"
+                ),
+                ExpressionAttributeValues={
+                    ":es": result.get("enrichment_status", ""),
+                    ":ea": result.get("enriched_at", ""),
+                    ":ep": result.get("enriched_phone", ""),
+                    ":ee": result.get("enriched_email", ""),
+                    ":en": result.get("enriched_name", ""),
+                    ":ei": result.get("enriched_identity_score", ""),
+                },
+            )
+        except Exception as exc:
+            logger.warning("Failed to write enrichment for contact %s: %s", contact_id, exc)
 
 
 def _clear_existing(document_id: str) -> tuple[int, int]:
@@ -586,13 +626,30 @@ def parse_document(document_id: str):
 
     contacts_written = 0
     properties_written = 0
+    contacts_list: list[dict] = []
     try:
-        contacts_written   = _write_contacts(document_id, parsed, _model_id, now, raw_response)
+        contacts_written, contacts_list = _write_contacts(document_id, parsed, _model_id, now, raw_response)
         properties_written = _write_properties(document_id, parsed, _model_id, now, raw_response)
     except Exception as exc:
         logger.error("DynamoDB write failed: %s", exc)
         _update_document_status(document_id, _model_id, now, error=str(exc))
         return {"error": f"DynamoDB write failed: {exc}"}, 500
+
+    # Enrich contacts via Enformion (best-effort — never blocks parse success)
+    if _enformion_ap_name and _enformion_ap_password:
+        try:
+            from enformion import enrich_contacts  # noqa: PLC0415
+            enrichment_results = enrich_contacts(
+                contacts_list, _enformion_ap_name, _enformion_ap_password
+            )
+            if enrichment_results:
+                _apply_enrichment(enrichment_results)
+                logger.info(
+                    "Enformion enrichment complete: %d contacts processed",
+                    len(enrichment_results),
+                )
+        except Exception as exc:
+            logger.error("Enformion enrichment failed (non-fatal): %s", exc)
 
     # 5. Stamp status on the documents table
     summary = parsed.get("summary") or ""

--- a/src/parse_document/enformion.py
+++ b/src/parse_document/enformion.py
@@ -1,0 +1,248 @@
+"""
+Enformion contact enrichment helper.
+
+enrich_contacts(contacts, ap_name, ap_password) -> list[dict]
+
+Enriches up to MAX_ENRICH non-deceased contacts in order, using the
+Enformion Contact Enrichment API (POST /Contact/Enrich).
+
+Fallback strategy:
+  - If the API returns 0 matches or >1 match, retry with state="TX" added
+    to the request.  If still ambiguous, skip enrichment for that contact.
+  - If the API returns exactly 1 match, use it.
+  - If an error occurs, record enrichment_status="error" and move on.
+
+Returns a list of update dicts, each containing contact_id plus any
+enriched fields (enriched_phone, enriched_email, enriched_name,
+enriched_identity_score, enrichment_status, enriched_at).
+"""
+
+import logging
+import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
+from typing import Optional
+
+import requests
+
+log = logging.getLogger(__name__)
+
+ENFORMION_URL = "https://devapi.enformion.com/Contact/Enrich"
+MAX_ENRICH = 10
+
+# ---------------------------------------------------------------------------
+# Name splitter
+# ---------------------------------------------------------------------------
+
+def _split_name(full_name: str) -> tuple[str, str]:
+    """Split 'First Last' into (first, last). Handles multiple words."""
+    parts = full_name.strip().split()
+    if not parts:
+        return "", ""
+    if len(parts) == 1:
+        return parts[0], ""
+    return parts[0], parts[-1]
+
+
+# ---------------------------------------------------------------------------
+# Single-contact enrichment
+# ---------------------------------------------------------------------------
+
+def _enrich_one(
+    contact_id: str,
+    name: str,
+    ap_name: str,
+    ap_password: str,
+    state_hint: Optional[str] = None,
+) -> dict:
+    """
+    Call Enformion for one contact.  Returns a result dict.
+    state_hint, when provided, is added to the request body as 'State'.
+    """
+    first, last = _split_name(name)
+    if not first and not last:
+        return {
+            "contact_id":             contact_id,
+            "enrichment_status":      "skipped",
+            "enriched_at":            _now_iso(),
+            "enriched_phone":         "",
+            "enriched_email":         "",
+            "enriched_name":          "",
+            "enriched_identity_score": "",
+        }
+
+    body: dict = {"FirstName": first, "LastName": last}
+    if state_hint:
+        body["State"] = state_hint
+
+    headers = {
+        "galaxy-ap-name":     ap_name,
+        "galaxy-ap-password": ap_password,
+        "Content-Type":       "application/json",
+    }
+
+    try:
+        resp = requests.post(ENFORMION_URL, json=body, headers=headers, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as exc:
+        log.warning("Enformion API error for contact %s: %s", contact_id, exc)
+        return {
+            "contact_id":             contact_id,
+            "enrichment_status":      "error",
+            "enriched_at":            _now_iso(),
+            "enriched_phone":         "",
+            "enriched_email":         "",
+            "enriched_name":          "",
+            "enriched_identity_score": "",
+        }
+
+    persons = data.get("Persons") or data.get("persons") or []
+    count = len(persons)
+
+    if count == 1:
+        return _extract_fields(contact_id, persons[0])
+
+    # 0 or multiple matches — caller should retry with TX
+    return None  # type: ignore[return-value]  # signals "retry"
+
+
+def _extract_fields(contact_id: str, person: dict) -> dict:
+    """Extract the fields we care about from one Enformion person record."""
+    # Phone — prefer mobile, fall back to first available
+    phones = person.get("Phones") or person.get("phones") or []
+    phone = ""
+    for p in phones:
+        if isinstance(p, dict):
+            num = p.get("Phone") or p.get("phone") or p.get("Number") or p.get("number") or ""
+            ptype = (p.get("Type") or p.get("type") or "").lower()
+            if num and ptype in ("mobile", "cell"):
+                phone = num
+                break
+    if not phone and phones:
+        first = phones[0]
+        if isinstance(first, dict):
+            phone = (
+                first.get("Phone") or first.get("phone") or
+                first.get("Number") or first.get("number") or ""
+            )
+        elif isinstance(first, str):
+            phone = first
+
+    # Email — first available
+    emails = person.get("Emails") or person.get("emails") or []
+    email = ""
+    for e in emails:
+        if isinstance(e, dict):
+            email = e.get("Email") or e.get("email") or e.get("Address") or e.get("address") or ""
+        elif isinstance(e, str):
+            email = e
+        if email:
+            break
+
+    # Full name from record
+    first_n = person.get("FirstName") or person.get("firstName") or ""
+    last_n  = person.get("LastName")  or person.get("lastName")  or ""
+    enriched_name = " ".join(filter(None, [first_n, last_n]))
+
+    # Identity score
+    score = str(
+        person.get("IdentityScore") or person.get("identityScore") or
+        person.get("Score") or person.get("score") or ""
+    )
+
+    return {
+        "contact_id":              contact_id,
+        "enrichment_status":       "success",
+        "enriched_at":             _now_iso(),
+        "enriched_phone":          phone,
+        "enriched_email":          email,
+        "enriched_name":           enriched_name,
+        "enriched_identity_score": score,
+    }
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def enrich_contacts(
+    contacts: list[dict],
+    ap_name: str,
+    ap_password: str,
+) -> list[dict]:
+    """
+    Enrich up to MAX_ENRICH non-deceased contacts.
+
+    contacts: list of dicts with at minimum 'contact_id', 'name', 'role'.
+    Returns a list of result dicts (one per contact attempted).
+    """
+    if not ap_name or not ap_password:
+        log.warning("Enformion credentials not set — skipping enrichment")
+        return []
+
+    # Filter: skip deceased, take first MAX_ENRICH
+    eligible = [
+        c for c in contacts
+        if (c.get("role") or "").lower() != "deceased"
+    ][:MAX_ENRICH]
+
+    if not eligible:
+        return []
+
+    results: list[dict] = []
+
+    def _work(contact: dict) -> dict:
+        cid  = contact["contact_id"]
+        name = contact.get("name") or ""
+        if not name.strip():
+            return {
+                "contact_id":              cid,
+                "enrichment_status":       "skipped",
+                "enriched_at":             _now_iso(),
+                "enriched_phone":          "",
+                "enriched_email":          "",
+                "enriched_name":           "",
+                "enriched_identity_score": "",
+            }
+
+        result = _enrich_one(cid, name, ap_name, ap_password)
+        if result is None:
+            # 0 or >1 match — retry with TX
+            result = _enrich_one(cid, name, ap_name, ap_password, state_hint="TX")
+        if result is None:
+            # Still ambiguous after TX fallback
+            result = {
+                "contact_id":              cid,
+                "enrichment_status":       "no_match",
+                "enriched_at":             _now_iso(),
+                "enriched_phone":          "",
+                "enriched_email":          "",
+                "enriched_name":           "",
+                "enriched_identity_score": "",
+            }
+        return result
+
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        futures = {pool.submit(_work, c): c for c in eligible}
+        for fut in as_completed(futures):
+            try:
+                results.append(fut.result())
+            except Exception as exc:
+                contact = futures[fut]
+                log.error("Enformion worker error for %s: %s", contact.get("contact_id"), exc)
+                results.append({
+                    "contact_id":              contact.get("contact_id", ""),
+                    "enrichment_status":       "error",
+                    "enriched_at":             _now_iso(),
+                    "enriched_phone":          "",
+                    "enriched_email":          "",
+                    "enriched_name":           "",
+                    "enriched_identity_score": "",
+                })
+
+    return results

--- a/src/parse_document/requirements.txt
+++ b/src/parse_document/requirements.txt
@@ -1,3 +1,4 @@
 aws-lambda-powertools>=2.30.0
 boto3>=1.34.0
+requests>=2.31.0
 usaddress>=0.5.10

--- a/template.yaml
+++ b/template.yaml
@@ -109,6 +109,21 @@ Parameters:
       Resend webhook signing secret (whsec_...).
       Leave blank to skip signature verification (local dev / CI).
 
+  EnformionApName:
+    Type: String
+    Default: ""
+    NoEcho: true
+    Description: >
+      Enformion galaxy-ap-name credential for contact enrichment.
+      Leave blank to skip enrichment (local dev / CI).
+
+  EnformionApPassword:
+    Type: String
+    Default: ""
+    NoEcho: true
+    Description: >
+      Enformion galaxy-ap-password credential for contact enrichment.
+      Leave blank to skip enrichment (local dev / CI).
 
   UiBucketName:
     Type: String
@@ -1085,6 +1100,8 @@ Resources:
           CONTACTS_TABLE_NAME: !Ref ContactsTable
           PROPERTIES_TABLE_NAME: !Ref PropertiesTable
           LINKS_TABLE_NAME: !Ref LinksTable
+          ENFORMION_AP_NAME: !Ref EnformionApName
+          ENFORMION_AP_PASSWORD: !Ref EnformionApPassword
       Policies:
         # Documents — read + stamp parsed_at
         - Statement:
@@ -1093,12 +1110,13 @@ Resources:
                 - dynamodb:GetItem
                 - dynamodb:UpdateItem
               Resource: !GetAtt DocumentsTable.Arn
-        # Contacts — write parsed contacts + query/delete for re-parse clearing
+        # Contacts — write parsed contacts + query/delete for re-parse clearing + enrichment updates
         - Statement:
             - Effect: Allow
               Action:
                 - dynamodb:PutItem
                 - dynamodb:BatchWriteItem
+                - dynamodb:UpdateItem
               Resource: !GetAtt ContactsTable.Arn
             - Effect: Allow
               Action:

--- a/template.yaml
+++ b/template.yaml
@@ -168,7 +168,7 @@ Conditions:
 Globals:
   Function:
     Runtime: python3.12
-    Architectures: [x86_64]
+    Architectures: [arm64]
     Environment:
       Variables:
         DOCUMENTS_TABLE_NAME: !Ref DocumentsTable
@@ -413,13 +413,34 @@ Resources:
           Projection:
             ProjectionType: ALL
 
-  # ── CloudWatch Log Group ──────────────────────────────────────────────────
+  # ── CloudWatch Log Groups ─────────────────────────────────────────────────
+  # Explicit log groups for all Lambda functions enforce retention so logs
+  # don't accumulate forever at $0.03/GB-month (SAM auto-created groups have
+  # no retention by default).
 
   ScraperLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: /ecs/probate-scraper
       RetentionInDays: 30
+
+  ApiFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: /aws/lambda/probate-leads-api
+      RetentionInDays: 30
+
+  TriggerFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: /aws/lambda/probate-leads-trigger
+      RetentionInDays: 14
+
+  ParseDocumentFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: /aws/lambda/probate-leads-parse-document
+      RetentionInDays: 14
 
   # ── ECS ───────────────────────────────────────────────────────────────────
 

--- a/tests/test_enformion.py
+++ b/tests/test_enformion.py
@@ -1,0 +1,239 @@
+"""
+Unit tests for src/parse_document/enformion.py
+
+Covers:
+  - Successful single-match enrichment with phone/email extraction
+  - Zero-match triggers TX fallback; TX fallback returns single match
+  - Zero-match with TX fallback still zero → no_match
+  - Multiple matches triggers TX fallback
+  - API error → error status
+  - Deceased contacts are skipped
+  - Contacts without names are skipped
+  - Limit capped at MAX_ENRICH (10)
+  - Missing credentials returns empty list immediately
+  - _split_name helper
+  - _extract_fields helper
+"""
+
+import sys
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+# Ensure enformion.py is importable
+_PARSE_DOC_SRC = os.path.join(os.path.dirname(__file__), "..", "src", "parse_document")
+sys.path.insert(0, _PARSE_DOC_SRC)
+
+from enformion import enrich_contacts, _split_name, _extract_fields, MAX_ENRICH  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _contact(cid: str, name: str, role: str = "executor") -> dict:
+    return {"contact_id": cid, "name": name, "role": role}
+
+
+def _api_response(persons: list) -> MagicMock:
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.json.return_value = {"Persons": persons}
+    return mock_resp
+
+
+_SENTINEL = object()
+
+def _person(first="John", last="Smith", phones=_SENTINEL, emails=_SENTINEL, score="95"):
+    return {
+        "FirstName": first,
+        "LastName": last,
+        "Phones": [{"Phone": "5551234567", "Type": "Mobile"}] if phones is _SENTINEL else phones,
+        "Emails": [{"Email": "john@example.com"}] if emails is _SENTINEL else emails,
+        "IdentityScore": score,
+    }
+
+
+# ---------------------------------------------------------------------------
+# _split_name
+# ---------------------------------------------------------------------------
+
+class TestSplitName(unittest.TestCase):
+    def test_two_parts(self):
+        self.assertEqual(_split_name("John Smith"), ("John", "Smith"))
+
+    def test_single(self):
+        self.assertEqual(_split_name("John"), ("John", ""))
+
+    def test_three_parts(self):
+        first, last = _split_name("John A Smith")
+        self.assertEqual(first, "John")
+        self.assertEqual(last, "Smith")
+
+    def test_empty(self):
+        self.assertEqual(_split_name(""), ("", ""))
+
+    def test_whitespace(self):
+        self.assertEqual(_split_name("  "), ("", ""))
+
+
+# ---------------------------------------------------------------------------
+# _extract_fields
+# ---------------------------------------------------------------------------
+
+class TestExtractFields(unittest.TestCase):
+    def test_basic(self):
+        person = _person()
+        result = _extract_fields("c1", person)
+        self.assertEqual(result["contact_id"], "c1")
+        self.assertEqual(result["enrichment_status"], "success")
+        self.assertEqual(result["enriched_phone"], "5551234567")
+        self.assertEqual(result["enriched_email"], "john@example.com")
+        self.assertEqual(result["enriched_name"], "John Smith")
+        self.assertEqual(result["enriched_identity_score"], "95")
+
+    def test_mobile_preferred_over_landline(self):
+        person = _person(phones=[
+            {"Phone": "5550000000", "Type": "Home"},
+            {"Phone": "5551234567", "Type": "Mobile"},
+        ])
+        result = _extract_fields("c1", person)
+        self.assertEqual(result["enriched_phone"], "5551234567")
+
+    def test_no_phones(self):
+        person = _person(phones=[])
+        result = _extract_fields("c1", person)
+        self.assertEqual(result["enriched_phone"], "")
+
+    def test_no_emails(self):
+        person = _person(emails=[])
+        result = _extract_fields("c1", person)
+        self.assertEqual(result["enriched_email"], "")
+
+
+# ---------------------------------------------------------------------------
+# enrich_contacts — happy path
+# ---------------------------------------------------------------------------
+
+class TestEnrichContacts(unittest.TestCase):
+
+    @patch("enformion.requests.post")
+    def test_single_match_success(self, mock_post):
+        mock_post.return_value = _api_response([_person()])
+        results = enrich_contacts(
+            [_contact("c1", "John Smith")],
+            ap_name="user", ap_password="pass"
+        )
+        self.assertEqual(len(results), 1)
+        r = results[0]
+        self.assertEqual(r["contact_id"], "c1")
+        self.assertEqual(r["enrichment_status"], "success")
+        self.assertEqual(r["enriched_phone"], "5551234567")
+        self.assertEqual(r["enriched_email"], "john@example.com")
+
+    @patch("enformion.requests.post")
+    def test_deceased_skipped(self, mock_post):
+        contacts = [
+            _contact("c1", "Jane Doe", role="deceased"),
+            _contact("c2", "John Smith", role="executor"),
+        ]
+        mock_post.return_value = _api_response([_person()])
+        results = enrich_contacts(contacts, ap_name="u", ap_password="p")
+        ids = [r["contact_id"] for r in results]
+        self.assertNotIn("c1", ids)
+        self.assertIn("c2", ids)
+
+    @patch("enformion.requests.post")
+    def test_no_name_skipped(self, mock_post):
+        results = enrich_contacts(
+            [_contact("c1", "", role="executor")],
+            ap_name="u", ap_password="p"
+        )
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["enrichment_status"], "skipped")
+        mock_post.assert_not_called()
+
+    def test_missing_credentials_returns_empty(self):
+        results = enrich_contacts(
+            [_contact("c1", "John Smith")],
+            ap_name="", ap_password=""
+        )
+        self.assertEqual(results, [])
+
+    @patch("enformion.requests.post")
+    def test_max_enrich_cap(self, mock_post):
+        mock_post.return_value = _api_response([_person()])
+        contacts = [_contact(f"c{i}", f"Person {i}") for i in range(15)]
+        results = enrich_contacts(contacts, ap_name="u", ap_password="p")
+        self.assertEqual(len(results), MAX_ENRICH)
+
+
+# ---------------------------------------------------------------------------
+# enrich_contacts — fallback and error paths
+# ---------------------------------------------------------------------------
+
+class TestEnrichContactsFallback(unittest.TestCase):
+
+    @patch("enformion.requests.post")
+    def test_zero_match_triggers_tx_fallback_success(self, mock_post):
+        # First call: 0 matches; second call (TX): 1 match
+        mock_post.side_effect = [
+            _api_response([]),           # initial: no matches
+            _api_response([_person()]),  # TX fallback: 1 match
+        ]
+        results = enrich_contacts(
+            [_contact("c1", "John Smith")],
+            ap_name="u", ap_password="p"
+        )
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["enrichment_status"], "success")
+        self.assertEqual(mock_post.call_count, 2)
+        # Verify TX was passed in second call
+        _, kwargs = mock_post.call_args
+        self.assertEqual(kwargs["json"]["State"], "TX")
+
+    @patch("enformion.requests.post")
+    def test_zero_match_tx_still_empty_gives_no_match(self, mock_post):
+        mock_post.return_value = _api_response([])
+        results = enrich_contacts(
+            [_contact("c1", "John Smith")],
+            ap_name="u", ap_password="p"
+        )
+        self.assertEqual(results[0]["enrichment_status"], "no_match")
+        self.assertEqual(mock_post.call_count, 2)
+
+    @patch("enformion.requests.post")
+    def test_multiple_matches_triggers_tx_fallback(self, mock_post):
+        mock_post.side_effect = [
+            _api_response([_person(), _person(first="Jane")]),  # 2 matches
+            _api_response([_person()]),                          # TX: 1 match
+        ]
+        results = enrich_contacts(
+            [_contact("c1", "John Smith")],
+            ap_name="u", ap_password="p"
+        )
+        self.assertEqual(results[0]["enrichment_status"], "success")
+
+    @patch("enformion.requests.post")
+    def test_api_error_returns_error_status(self, mock_post):
+        mock_post.side_effect = Exception("Connection refused")
+        results = enrich_contacts(
+            [_contact("c1", "John Smith")],
+            ap_name="u", ap_password="p"
+        )
+        self.assertEqual(results[0]["enrichment_status"], "error")
+
+    @patch("enformion.requests.post")
+    def test_http_error_returns_error_status(self, mock_post):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.side_effect = Exception("403 Forbidden")
+        mock_post.return_value = mock_resp
+        results = enrich_contacts(
+            [_contact("c1", "John Smith")],
+            ap_name="u", ap_password="p"
+        )
+        self.assertEqual(results[0]["enrichment_status"], "error")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -85,6 +85,13 @@ export interface Contact {
   parsedModel?: string
   rawResponse?: string
   links?: Link[]
+  // Enformion enrichment fields
+  enrichmentStatus?: 'success' | 'no_match' | 'error' | 'skipped' | ''
+  enrichedAt?: string
+  enrichedPhone?: string
+  enrichedEmail?: string
+  enrichedName?: string
+  enrichedIdentityScore?: string
 }
 
 export interface Property {

--- a/ui/src/pages/DocumentDetail.tsx
+++ b/ui/src/pages/DocumentDetail.tsx
@@ -28,7 +28,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
-import { CheckCircle, ExternalLink, Link2, Pencil, Trash2, X } from 'lucide-react'
+import { CheckCircle, ExternalLink, Link2, MinusCircle, Pencil, Trash2, X, XCircle } from 'lucide-react'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -48,6 +48,38 @@ function roleBadgeVariant(role: string): 'default' | 'secondary' | 'outline' {
   if (role === 'deceased') return 'default'
   if (role === 'executor') return 'secondary'
   return 'outline'
+}
+
+function EnrichmentIcon({ contact }: { contact: Contact }) {
+  const status = contact.enrichmentStatus
+  if (!status) return null
+
+  if (status === 'success') {
+    const tip = [
+      contact.enrichedName  && `Name: ${contact.enrichedName}`,
+      contact.enrichedPhone && `Phone: ${contact.enrichedPhone}`,
+      contact.enrichedEmail && `Email: ${contact.enrichedEmail}`,
+      contact.enrichedIdentityScore && `Score: ${contact.enrichedIdentityScore}`,
+    ].filter(Boolean).join(' · ') || 'Enriched'
+    return (
+      <span title={`Enformion: ${tip}`} className="shrink-0">
+        <CheckCircle size={13} className="text-green-500" />
+      </span>
+    )
+  }
+  if (status === 'error') {
+    return (
+      <span title="Enformion: enrichment error" className="shrink-0">
+        <XCircle size={13} className="text-destructive" />
+      </span>
+    )
+  }
+  // no_match or skipped
+  return (
+    <span title={`Enformion: ${status}`} className="shrink-0">
+      <MinusCircle size={13} className="text-muted-foreground" />
+    </span>
+  )
 }
 
 const ROLE_ORDER: Record<string, number> = {
@@ -505,6 +537,7 @@ function ContactRow({
         <TableCell className="font-medium whitespace-nowrap">
           <span className="flex items-center gap-1.5">
             {contact.name || '—'}
+            <EnrichmentIcon contact={contact} />
             {links.map(link => (
               <LinkIcon
                 key={link.linkId}


### PR DESCRIPTION
## Summary
- Calls Enformion Contact Enrichment API after parsing a document, enriching up to 10 non-deceased contacts in order
- TX-state fallback when 0 or >1 result is returned; marks `no_match` if still ambiguous after retry
- Enrichment is best-effort — failures log a warning but never fail the parse response
- New Contact fields: `enrichment_status`, `enriched_at`, `enriched_phone`, `enriched_email`, `enriched_name`, `enriched_identity_score`
- UI shows ✅ / ✗ / − icon next to each contact name in DocumentDetail based on `enrichmentStatus`

## Infrastructure changes
- Two new SAM parameters: `EnformionApName` / `EnformionApPassword` (NoEcho)
- Added `ENFORMION_AP_NAME` + `ENFORMION_AP_PASSWORD` env vars to `ParseDocumentFunction`
- Added `dynamodb:UpdateItem` to ParseDocumentFunction's ContactsTable IAM policy
- Wired `ENFORMION_AP_NAME` / `ENFORMION_AP_PASSWORD` GitHub secrets into deploy workflow

## Setup required
Add GitHub secrets `ENFORMION_AP_NAME` and `ENFORMION_AP_PASSWORD` before deploying.

## Test plan
- [ ] `make test` — 544 tests pass (16 new in `test_enformion.py`)
- [ ] Parse a document with Enformion credentials set; confirm enrichment fields written to contacts table
- [ ] Parse with credentials unset; confirm enrichment is silently skipped
- [ ] Verify green/red/grey icon appears next to enriched contact names in DocumentDetail

## Session log
docs/sessions/2026-03-18-1231a660.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)